### PR TITLE
Add Http Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,22 +362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-tungstenite"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b30ef0ea5c20caaa54baea49514a206308989c68be7ecd86c7f956e4da6378"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite",
- "tokio",
- "tokio-rustls",
- "tungstenite 0.13.0",
- "webpki-roots",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1610,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2141,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -3223,6 +3242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,6 +4205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,9 +4258,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4274,6 +4309,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,7 +4331,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-native-tls",
- "tungstenite 0.12.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4325,6 +4371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4452,29 +4499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tungstenite"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
-dependencies = [
- "base64",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "input_buffer",
- "log",
- "rand 0.8.4",
- "rustls",
- "sha-1",
- "thiserror",
- "url",
- "utf-8",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
 name = "twox-hash"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,6 +4531,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -4605,6 +4638,35 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4779,7 +4841,6 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "async-tungstenite",
  "bulletproofs-gadgets",
  "config",
  "curve25519-dalek 3.1.0",
@@ -4798,6 +4859,7 @@ dependencies = [
  "structopt",
  "tokio",
  "url",
+ "warp",
  "webb",
  "webb-bulletproofs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ url = "^2.2"
 futures = { version = "^0.3", default-features = false }
 serde = { version = "^1", default-features = false, features = ["derive"] }
 tokio = { version = "^1", features = ["full"] }
+warp = { version = "0.3.1", default-features = false, features = ["websocket", "tls"] }
 config = { version = "0.11", default-features = false, features = ["toml", "json"] }
 serde_json = { version = "^1", default-features = false }
 webb = { version = "0.1.0", git = "https://github.com/webb-tools/webb-rs.git" }
@@ -27,11 +28,6 @@ directories-next = "^2.0"
 # until ethers-rs solve this issue: https://github.com/gakonst/ethers-rs/issues/325
 native-tls = { version = "^0.2", features = ["vendored"] }
 
-[dependencies.tungstenite]
-package = "async-tungstenite"
-version = "^0.13"
-default-features = false
-features = ["tokio-runtime", "tokio-rustls"]
 
 [dev-dependencies]
 sp-keyring = "^3"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::large_enum_variant)]
 
+use std::convert::Infallible;
 use std::error::Error;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_stream::stream;
@@ -63,6 +65,18 @@ where
         },
     };
     Ok(())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IpInformationResponse {
+    ip: Option<SocketAddr>,
+}
+
+pub async fn handle_ip_info(
+    ip: Option<SocketAddr>,
+) -> Result<impl warp::Reply, Infallible> {
+    Ok(warp::reply::json(&IpInformationResponse { ip }))
 }
 
 /// Proof data for withdrawal

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,10 +8,7 @@ use chains::evm;
 use futures::prelude::*;
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
-use tokio::net::TcpStream;
-use tungstenite::tokio::accept_async_with_config;
-use tungstenite::tungstenite::protocol::WebSocketConfig;
-use tungstenite::tungstenite::Message;
+use warp::ws::Message;
 use webb::evm::contract::anchor::AnchorContract;
 use webb::evm::ethereum_types::{Address, H256, U256};
 use webb::evm::ethers::prelude::*;
@@ -26,46 +23,34 @@ use crate::chains;
 use crate::context::RelayerContext;
 
 pub async fn accept_connection(
-    ctx: RelayerContext,
-    stream: TcpStream,
+    ctx: &RelayerContext,
+    stream: warp::ws::WebSocket,
 ) -> anyhow::Result<()> {
-    let config = WebSocketConfig {
-        max_send_queue: Some(5),
-        max_message_size: Some(2 << 20), // 5MB
-        ..Default::default()
-    };
-    let peer_addr = stream.peer_addr().unwrap();
-    let ws_stream = accept_async_with_config(stream, Some(config)).await?;
-    let (mut tx, mut rx) = ws_stream.split();
+    let (mut tx, mut rx) = stream.split();
     while let Some(msg) = rx.try_next().await? {
-        match msg {
-            Message::Text(v) => handle_text(&ctx, v, &mut tx).await?,
-            Message::Binary(_) => {
-                // should we close the connection?
-            },
-            _ => continue,
+        if let Ok(text) = msg.to_str() {
+            handle_text(ctx, text, &mut tx).await?;
         }
     }
-    log::debug!("Client disconnected: {}", peer_addr);
     Ok(())
 }
 
 pub async fn handle_text<TX>(
     ctx: &RelayerContext,
-    v: String,
+    v: &str,
     tx: &mut TX,
 ) -> anyhow::Result<()>
 where
     TX: Sink<Message> + Unpin,
     TX::Error: Error + Send + Sync + 'static,
 {
-    match serde_json::from_str(&v) {
+    match serde_json::from_str(v) {
         Ok(cmd) => {
             handle_cmd(ctx.clone(), cmd)
                 .fuse()
                 .map(|v| serde_json::to_string(&v).expect("bad value"))
                 .inspect(|v| log::trace!("Sending: {}", v))
-                .map(Message::Text)
+                .map(Message::text)
                 .map(Result::Ok)
                 .forward(tx)
                 .await?;
@@ -74,7 +59,7 @@ where
             log::warn!("Got invalid payload: {:?}", e);
             let error = CommandResponse::Error(e.to_string());
             let value = serde_json::to_string(&error)?;
-            tx.send(Message::Text(value)).await?
+            tx.send(Message::text(value)).await?
         },
     };
     Ok(())

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -348,7 +348,7 @@ async function main() {
   console.log('Starting the Relayer ..');
   const relayer = await startWebbRelayer();
   await sleep(500); // just to wait for the relayer start-up
-  const client = new WebSocket('ws://localhost:9955');
+  const client = new WebSocket('ws://localhost:9955/ws');
   await new Promise((resolve) => client.on('open', resolve));
   console.log('Connected to Relayer!');
 


### PR DESCRIPTION
This will update the relayer architecture to handle both HTTP Requests and WebSockets.

This PR however is not for adding the new Endpoints per Http Relayer Spec, it would only contain the part to support serving HTTP Requests, following PRs would be for adding small functionality and new endpoints.