### PR TITLE
feat: better error messages

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+relayer = "run -q -- -c tests/config.toml"

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,9 @@ fn setup_logger(verbosity: i32) -> anyhow::Result<()> {
     let env_filter = tracing_subscriber::EnvFilter::from_default_env()
         .add_directive(format!("webb_relayer={}", log_level).parse()?);
     tracing_subscriber::fmt()
+        .pretty()
+        .with_level(false)
+        .with_target(false)
         .with_max_level(log_level)
         .with_env_filter(env_filter)
         .init();

--- a/tests/proofUtils.ts
+++ b/tests/proofUtils.ts
@@ -14,14 +14,17 @@ type EvmLeavesResponse = {
   leaves: [{ commitment: string }];
 };
 
-const toHex = (number: number | Buffer, length = 32) =>
+export const toHex = (number: number | Buffer, length = 32) =>
   '0x' +
   (number instanceof Buffer
     ? number.toString('hex')
     : snarkjs.bigInt(number).toString(16)
   ).padStart(length * 2, '0');
 
-export async function getAnchorDenomination(contractAddress: string, provider: ethers.providers.JsonRpcProvider): Promise<string> {
+export async function getAnchorDenomination(
+  contractAddress: string,
+  provider: ethers.providers.Provider
+): Promise<string> {
   const nativeAnchorInstance = new ethers.Contract(
     contractAddress,
     nativeAnchorContract.abi,
@@ -33,7 +36,10 @@ export async function getAnchorDenomination(contractAddress: string, provider: e
 }
 
 // BigNumber for principle
-export const calculateFee = (withdrawFeePercentage: number, principle: string): string => {
+export const calculateFee = (
+  withdrawFeePercentage: number,
+  principle: string
+): string => {
   const principleBig = snarkjs.bigInt(principle);
   const withdrawFeeMill = withdrawFeePercentage * 1000000;
   const withdrawFeeMillBig = snarkjs.bigInt(withdrawFeeMill);
@@ -42,7 +48,7 @@ export const calculateFee = (withdrawFeePercentage: number, principle: string): 
   const fee = feeBig.toString();
 
   return fee;
-}
+};
 
 function createDeposit() {
   const rbigint = (nbytes: number) =>
@@ -87,7 +93,10 @@ export async function deposit(contractAddress: string, wallet: ethers.Signer) {
   return deposit;
 }
 
-export async function getDepositLeavesFromChain(contractAddress: string, provider: ethers.providers.JsonRpcProvider) {
+export async function getDepositLeavesFromChain(
+  contractAddress: string,
+  provider: ethers.providers.Provider
+) {
   // Query the blockchain for all deposits that have happened
   const anchorInterface = new ethers.utils.Interface(anchorContract.abi);
   const anchorInstance = new ethers.Contract(
@@ -146,12 +155,12 @@ export async function generateSnarkProof(
   deposit: any,
   recipient: string,
   relayer: string,
-  fee: string,
+  fee: string
 ) {
   // find the inputs that correspond to the path for the deposit
   const { root, path_elements, path_index } = await generateMerkleProof(
     leaves,
-    deposit,
+    deposit
   );
 
   let groth16 = await buildGroth16();


### PR DESCRIPTION
This PR improves the error messages to be more structured for the dApp to view.
now when there is an error that happens on the relayer side during the withdrawal process, the dApp should expect something like this (in JSON).

```js
{
  withdraw: {
    errored: { code: -32000, reason: 'Invalid withdraw proof' },
  },
}
```
The error code is the same as we see from the JSONRPC error codes.