### PR TITLE
Move the Withdraw Configration to be per Anchor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webb-relayer"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 authors = ["Shady Khalifa <shekohex@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Example:
 # Webb Relayer Network Port
 # default: 9955
 port = 9955
+[substrate.webb]
+suri = "//Alice"
 
 [evm.harmony]
 # Http(s) Endpoint for quick Req/Res
@@ -58,12 +60,6 @@ chain-id = 1666700001
 # 4. if it doesn't contains special characters and has 12 or 24 words in it
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "0x8917174396171783496173419137618235192359106130478137647163400318"
-# The fee percentage that your account will receive when you relay a transaction
-# over this chain.
-withdraw-fee-percentage = "0.05"
-# A hex value of the gaslimit when doing a withdraw relay transaction
-# on this chain.
-withdraw-gaslimit = "0x350000"
 
 # chain contracts
 [[evm.harmony.contracts]]
@@ -84,6 +80,12 @@ size = 0.0000000001
 # control the leaves watcher for this contract
 # Note: only available for `Anchor` and `Anchor2` contracts.
 leaves-watcher = { enabled = false, polling-interval = 3000 }
+# The fee percentage that your account will receive when you relay a transaction
+# over this chain.
+withdraw-fee-percentage = 0.05
+# A hex value of the gaslimit when doing a withdraw relay transaction
+# on this chain.
+withdraw-gaslimit = "0x350000"
 
 [[evm.harmony.contracts]]
 contract = "Anchor"
@@ -91,6 +93,8 @@ address = "0x7cd1F52e5EEdf753e99D945276a725CE533AaD1a"
 deployed-at = 12040000
 size = 100
 leaves-watcher = { enabled = false, polling-interval = 3000 }
+withdraw-fee-percentage = 0.05
+withdraw-gaslimit = "0x350000"
 
 # and so on for other networks and other contracts ...
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,13 +58,6 @@ pub struct ChainConfig {
     ///   then we should process it as a mnemonic string: 'word two three four ...'
     #[serde(skip_serializing)]
     pub private_key: PrivateKey,
-    /// The fee percentage that your account will receive when you relay a transaction
-    /// over this chain.
-    #[serde(rename(serialize = "withdrawFeePercentage"))]
-    pub withdraw_fee_percentage: f64,
-    /// A hex value of the gaslimit when doing a withdraw relay transaction on this chain.
-    #[serde(skip_serializing)]
-    pub withdraw_gaslimit: U256,
     /// INTERNAL: got updated with the account address of the private key.
     #[serde(skip_deserializing)]
     pub account: Option<Address>,
@@ -81,6 +74,18 @@ pub struct AnchorLeavesWatcherConfig {
     /// Polling interval in milliseconds
     #[serde(rename(serialize = "pollingInterval"))]
     pub polling_interval: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct AnchorWithdrawConfig {
+    /// The fee percentage that your account will receive when you relay a transaction
+    /// over this chain.
+    #[serde(rename(serialize = "withdrawFeePercentage"))]
+    pub withdraw_fee_percentage: f64,
+    /// A hex value of the gaslimit when doing a withdraw relay transaction on this chain.
+    #[serde(skip_serializing)]
+    pub withdraw_gaslimit: U256,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,6 +117,9 @@ pub struct AnchorContractConfig {
     pub leaves_watcher: AnchorLeavesWatcherConfig,
     /// The size of this contract
     pub size: f64,
+    /// Anchor withdraw configuration.
+    #[serde(flatten)]
+    pub withdraw_config: AnchorWithdrawConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,15 +67,6 @@ impl RelayerContext {
         let wallet = LocalWallet::from(key).with_chain_id(chain_id);
         Ok(wallet)
     }
-
-    pub fn fee_percentage(&self, chain_name: &str) -> anyhow::Result<f64> {
-        let chain_config = self
-            .config
-            .evm
-            .get(chain_name)
-            .context("this chain not configured")?;
-        Ok(chain_config.withdraw_fee_percentage)
-    }
 }
 
 /// Listens for the server shutdown signal.

--- a/src/events_watcher/anchor_leaves_watcher.rs
+++ b/src/events_watcher/anchor_leaves_watcher.rs
@@ -128,6 +128,10 @@ mod tests {
                 polling_interval: 1000,
             },
             size: 1.0,
+            withdraw_config: AnchorWithdrawConfig {
+                withdraw_fee_percentage: 0.0000000001,
+                withdraw_gaslimit: 0.into(),
+            },
         };
 
         let inner_client = Arc::new(client.provider().clone());

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -29,12 +29,6 @@ chain-id = 1666700001
 # 4. if it doesn't contains special characters and has 12 or 24 words in it
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "0x8917174396171783496173419137618235192359106130478137647163400318"
-# The fee percentage that your account will receive when you relay a transaction
-# over this chain.
-withdraw-fee-percentage = "0.05"
-# A hex value of the gaslimit when doing a withdraw relay transaction
-# on this chain.
-withdraw-gaslimit = "0x350000"
 
 # chain contracts
 [[evm.harmony.contracts]]
@@ -55,6 +49,12 @@ size = 0.0000000001
 # control the leaves watcher for this contract
 # Note: only available for `Anchor` and `Anchor2` contracts.
 leaves-watcher = { enabled = false, polling-interval = 3000 }
+# The fee percentage that your account will receive when you relay a transaction
+# over this chain.
+withdraw-fee-percentage = 0.05
+# A hex value of the gaslimit when doing a withdraw relay transaction
+# on this chain.
+withdraw-gaslimit = "0x350000"
 
 [[evm.harmony.contracts]]
 contract = "Anchor"
@@ -62,6 +62,8 @@ address = "0x7cd1F52e5EEdf753e99D945276a725CE533AaD1a"
 deployed-at = 12040000
 size = 100
 leaves-watcher = { enabled = false, polling-interval = 3000 }
+withdraw-fee-percentage = 0.05
+withdraw-gaslimit = "0x350000"
 
 # and so on for other networks and other contracts ...
 
@@ -70,8 +72,6 @@ http-endpoint = "http://localhost:8545"
 ws-endpoint = "ws://localhost:8545"
 chain-id = 1337
 private-key = "0xc0d375903fd6f6ad3edafc2c5428900c0757ce1da10e5dd864fe387b32b91d7e"
-withdraw-fee-percentage = "0.05"
-withdraw-gaslimit = "0x350000"
 
 [[evm.ganache.contracts]]
 contract = "Anchor"
@@ -79,14 +79,14 @@ address = "0xFBD61C9961e0bf872B5Ec041b718C0B2a106Ce9D"
 deployed-at = 1
 size = 1
 leaves-watcher = { enabled = false, polling-interval = 1000 }
+withdraw-fee-percentage = 0.05
+withdraw-gaslimit = "0x350000"
 
 [evm.beresheet]
 http-endpoint = "https://beresheet.edgewa.re/evm"
 ws-endpoint = "wss://beresheet.edgewa.re"
 chain-id = 2022
 private-key = "0x8917174396171783496173419137618235192359106130478137647163400318"
-withdraw-fee-percentage = "0.05"
-withdraw-gaslimit = "0x350000"
 
 [[evm.beresheet.contracts]]
 contract = "Anchor"
@@ -94,14 +94,14 @@ address = "0xf0EA8Fa17daCF79434d10C51941D8Fc24515AbE3"
 deployed-at = 299740
 size = 10
 leaves-watcher = { enabled = false, polling-interval = 7000 }
+withdraw-fee-percentage = 0.05
+withdraw-gaslimit = "0x350000"
 
 [evm.rinkeby]
 http-endpoint = "https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
 ws-endpoint = "wss://rinkeby.infura.io/ws/v3/9aa3d95b3bc440fa88ea12eaa4456161"
 chain-id = 4
 private-key = "0x8917174396171783496173419137618235192359106130478137647163400318"
-withdraw-fee-percentage = "0.05"
-withdraw-gaslimit = "0x350000"
 
 [[evm.rinkeby.contracts]]
 contract = "Anchor"
@@ -109,3 +109,6 @@ address = "0x626FEc5Ffa7Bf1EE8CEd7daBdE545630473E3ABb"
 deployed-at = 8896800
 size = 0.1
 leaves-watcher = { enabled = false, polling-interval = 7000 }
+withdraw-fee-percentage = 0.05
+withdraw-gaslimit = "0x350000"
+

--- a/tests/integration_tests/testGanache.ts
+++ b/tests/integration_tests/testGanache.ts
@@ -142,11 +142,15 @@ describe('Ganache Relayer Withdraw Tests', function () {
       'ganache',
       'http://localhost:9955'
     );
-    console.log({ relayerChainInfo });
+    console.log(JSON.stringify(relayerChainInfo));
+
+    const contractConfig = relayerChainInfo.contracts.find(
+      (e) => e.address.toLowerCase() === contractAddress.toLowerCase()
+    );
 
     // save the relayer configured parameters
     calculatedFee = calculateFee(
-      relayerChainInfo.withdrawFeePercentage,
+      contractConfig?.withdrawFeePercentage ?? 0.0,
       contractDenomination
     );
   });

--- a/tests/relayerUtils.ts
+++ b/tests/relayerUtils.ts
@@ -4,7 +4,7 @@ require('dotenv').config({ path: '.env' });
 
 export type RelayerChainConfig = {
   chainName: string;
-  withdrawFeePercentage: number;
+  contracts: [{ address: string; withdrawFeePercentage: number }];
   account: string;
 };
 
@@ -37,7 +37,7 @@ export const getRelayerConfig = async (
   return {
     chainName: chainName,
     account: relayerInfo.evm[chainName].account,
-    withdrawFeePercentage: relayerInfo.evm[chainName].withdrawFeePercentage,
+    contracts: relayerInfo.evm[chainName].contracts,
   };
 };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features) @nepoche will create a PR for the docs.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `withdraw-fee-percentage` and `withdraw-gaslimit` are in the global configuration.


## What is the new behavior?

The `withdraw-fee-percentage` and `withdraw-gaslimit` are now defined in per `Anchor` contract.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

As I mentioned in the new behavior, it makes more sense to move this configuration to be per `Anchor` Contract, instead of the global configuration.


## Other information

This would be included in the first stable release of Webb Relayer `v0.1.0`