### PR TITLE
Prevent infinite loop in error handling

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -579,19 +579,19 @@ fn handle_anchor_relay_tx<'a>(
     };
     s.boxed()
 }
+
 fn into_withdraw_error<M: Middleware>(e: ContractError<M>) -> WithdrawStatus {
     // a poor man error parser
     // WARNING: **don't try this at home**.
-
     let msg = format!("{}", e);
     // split the error into words, lazily.
     let mut words = msg.split_whitespace();
-    // skip until we find the "(code:" span
-    let code = loop {
-        if words.next() == Some("(code:") {
-            // the next is the code.
-            // example: "-32000,"
-            let code: i32 = match words.next() {
+    let mut reason = "unknown".to_string();
+    let mut code = -1;
+
+    while let Some(current_word) = words.next() {
+        if current_word == "(code:" {
+            code = match words.next() {
                 Some(val) => {
                     let mut v = val.to_string();
                     v.pop(); // remove ","
@@ -599,24 +599,19 @@ fn into_withdraw_error<M: Middleware>(e: ContractError<M>) -> WithdrawStatus {
                 }
                 _ => -1, // unknown code
             };
-            break code;
         }
-    };
-
-    let reason = loop {
-        // skip until we find this
-        if words.next() == Some("transaction:") {
-            // next we need to collect all words in between "transaction:"
+        else if current_word == "message:" {
+            // next we need to collect all words in between "message:"
             // and "data:", that would be the error message.
             let msg: Vec<_> = words
-                .skip(1) // word "revert"
+                .clone()
                 .take_while(|v| *v != "data:")
                 .collect();
-            let mut reason = msg.join(" ");
+            reason = msg.join(" ");
             reason.pop(); // remove the "," at the end.
-            break reason;
         }
-    };
+    }
+
     WithdrawStatus::Errored { reason, code }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -599,14 +599,11 @@ fn into_withdraw_error<M: Middleware>(e: ContractError<M>) -> WithdrawStatus {
                 }
                 _ => -1, // unknown code
             };
-        }
-        else if current_word == "message:" {
+        } else if current_word == "message:" {
             // next we need to collect all words in between "message:"
             // and "data:", that would be the error message.
-            let msg: Vec<_> = words
-                .clone()
-                .take_while(|v| *v != "data:")
-                .collect();
+            let msg: Vec<_> =
+                words.clone().take_while(|v| *v != "data:").collect();
             reason = msg.join(" ");
             reason.pop(); // remove the "," at the end.
         }

--- a/tests/proofUtils.ts
+++ b/tests/proofUtils.ts
@@ -102,6 +102,24 @@ export async function deposit(contractAddress: string, wallet: ethers.Signer) {
   return deposit;
 }
 
+export async function withdraw(contractAddress: string, proof: any, args: any, wallet: ethers.Signer) {
+  const nativeAnchorInstance = new ethers.Contract(
+    contractAddress,
+    nativeAnchorContract.abi,
+    wallet
+  );
+
+  const withdrawTx = await nativeAnchorInstance.withdraw(
+    proof, 
+    ...args,
+    {
+      gasLimit: 6000000
+    }
+  );
+  const receipt = await withdrawTx.wait();
+  return receipt;
+}
+
 export async function getDepositLeavesFromChain(
   contractAddress: string,
   provider: ethers.providers.Provider


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Current withdraw error handler loops until it finds a specific string 'transaction:'; however, in the case of double spend, the message passed to withdraw error handle did not have this string - resulting in an infinite loop.

Issue Number: N/A

## What is the new behavior?
Only loop over the words of the given message; parse on the more verbose but present 'message:' string instead.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
