### PR TITLE
Update configuration deserialization to be fault-tolerant of missing env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "parking_lot",
  "paw",
  "rand 0.8.4",
+ "regex",
  "serde",
  "serde_json",
  "sled",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,7 +3699,6 @@ dependencies = [
  "parking_lot",
  "paw",
  "rand 0.8.4",
- "regex",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ thiserror = "^1.0"
 glob = "^0.3"
 headers = "0.3.5"
 dotenv = "0.15.0"
-regex = "1.5.4"
 serde_path_to_error = "0.1.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = "^1.0"
 glob = "^0.3"
 headers = "0.3.5"
 dotenv = "0.15.0"
+regex = "1.5.4"
 
 [dev-dependencies]
 tempfile = "^3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webb-relayer"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Shady Khalifa <shekohex@gmail.com>"]
 edition = "2018"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,7 +255,11 @@ pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<WebbRelayerConfig> {
             }
             Err(e) => {
                 // print the issue that occurred while deserializing, then skip that config
-                tracing::debug!("Error {} while attempting to deserialize {}", e, base);
+                tracing::debug!(
+                    "Error {} while attempting to deserialize {}",
+                    e,
+                    base
+                );
                 &cfg
             }
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -256,10 +256,14 @@ pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<WebbRelayerConfig> {
         let file = config::File::from(config_file).format(FileFormat::Toml);
         let mut incremental_config = config::Config::new();
         incremental_config.merge(file.clone())?;
-        match incremental_config.try_into::<WebbRelayerConfig>() {
+        let config: Result<
+            WebbRelayerConfig,
+            serde_path_to_error::Error<config::ConfigError>,
+        > = serde_path_to_error::deserialize(incremental_config);
+        match config {
             Ok(_) => {
                 // merge the file into the cfg
-                cfg.merge(file)?
+                cfg.merge(file)?;
             }
             Err(e) => {
                 // print the issue that occurred while deserializing, then skip that config
@@ -268,7 +272,6 @@ pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<WebbRelayerConfig> {
                     e,
                     base
                 );
-                &cfg
             }
         };
     }

--- a/tests/config/rinkeby.toml
+++ b/tests/config/rinkeby.toml
@@ -1,0 +1,28 @@
+[evm.rinkeby]
+http-endpoint = "https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+ws-endpoint = "wss://rinkeby.infura.io/ws/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+explorer = "https://rinkeby.etherscan.io"
+chain-id = 4
+private-key = "$RINKEBY_PRIVATE_KEY"
+
+[[evm.rinkeby.contracts]]
+contract = "Tornado"
+address = "0x626FEc5Ffa7Bf1EE8CEd7daBdE545630473E3ABb"
+deployed-at = 8896800
+size = 0.1
+events-watcher = { enabled = false, polling-interval = 15000 }
+withdraw-fee-percentage = 0.05
+withdraw-gaslimit = "0x350000"
+
+[[evm.rinkeby.contracts]]
+contract = "Anchor"
+address = "0x33EAD0AE289f172E00BDD2e5c39BDF5b18F9d63A"
+deployed-at = 9537650
+size = 0.0000000000001
+events-watcher = { enabled = true, polling-interval = 15000 }
+withdraw-fee-percentage = 0
+withdraw-gaslimit = "0x350000"
+linked-anchors = [
+  { chain = "ropsten", address = "0xB039952e6A46b890e2a44835d97dE253482b2Ca2" },
+  { chain = "goerli", address = "0x19b72e48a90975a5B9F88C5ae907607A13bf827A" },
+]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
Added unused config with undefined environment variable in tests directory

- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Users define the networks they wish to support with the appropriate WEBB_EVM_network_ENABLED and network_PRIVATE_KEY environment variables. However, errors still appear for networks they do not intend to support, because the environment variables for private keys for these unsupported networks do not exist.

## What is the new behavior?
Incrementally deserialize each config file, and include the config to the relayer runtime if appropriately parsed. If deserialization fails for whatever reason, skip that config and continue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
