### PR TITLE
imporve error messages for loading config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0421d4f173fab82d72d6babf36d57fae38b994ca5c2d78e704260ba6d12118b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,6 +3701,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sled",
  "structopt",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = "^1.0"
 glob = "^0.3"
 headers = "0.3.5"
 dotenv = "0.15.0"
+serde_path_to_error = "0.1.5"
 
 [dev-dependencies]
 tempfile = "^3.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
 
+use config::FileFormat;
 use serde::{Deserialize, Serialize};
 use webb::evm::ethereum_types::{Address, Secret, U256};
 
@@ -211,20 +212,26 @@ impl<'de> Deserialize<'de> for PrivateKey {
             {
                 if value.starts_with("0x") {
                     // hex value
-                    Secret::from_str(value)
-                        .map_err(|e| serde::de::Error::custom(e.to_string()))
+                    let maybe_hex = Secret::from_str(value);
+                    match maybe_hex {
+                        Ok(val) => Ok(val),
+                        Err(e) => Err(serde::de::Error::custom(format!("{}\n got {} but expected a 66 string (including the 0x prefix)", e, value))),
+                    }
                 } else if value.starts_with('$') {
                     // env
                     let var = value.strip_prefix('$').unwrap_or(value);
+                    tracing::trace!("Reading {} from env", var);
                     let val = std::env::var(var).map_err(|e| {
                         serde::de::Error::custom(format!(
-                            "{}: {}",
-                            e.to_string(),
-                            var
+                            "error while loading this env {}: {}",
+                            var, e,
                         ))
                     })?;
-                    Secret::from_str(&val)
-                        .map_err(|e| serde::de::Error::custom(e.to_string()))
+                    let maybe_hex = Secret::from_str(&val);
+                    match maybe_hex {
+                        Ok(val) => Ok(val),
+                        Err(e) => Err(serde::de::Error::custom(format!("{}\n got {} but expected a 66 chars string (including the 0x prefix) but found {} char", e, val, val.len()))),
+                    }
                 } else if value.starts_with('>') {
                     todo!("Implement command execution to extract the private key")
                 } else {
@@ -245,14 +252,21 @@ pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<WebbRelayerConfig> {
     // then get an iterator over all matching files
     let config_files = glob::glob(&pattern)?.flatten();
     for config_file in config_files {
-        let base = config_file.display().to_string();
+        let file = config::File::from(config_file).format(FileFormat::Toml);
         // merge the file into the config
-        cfg.merge(config::File::with_name(&base))?;
+        cfg.merge(file)?;
     }
     // also merge in the environment (with a prefix of WEBB).
     cfg.merge(config::Environment::with_prefix("WEBB").separator("_"))?;
     // and finally deserialize the config and post-process it
-    postloading_process(cfg.try_into()?)
+    let config = serde_path_to_error::deserialize(cfg);
+    match config {
+        Ok(config) => postloading_process(config),
+        Err(e) => {
+            tracing::error!("{}", e);
+            anyhow::bail!("Error while loading config files")
+        }
+    }
 }
 
 fn postloading_process(

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ where
         return Err(anyhow::anyhow!("{} is not a directory", path.display()));
     }
     tracing::trace!("Loading Config from {} ..", path.display());
-    config::load(path).context("failed to load the config files")
+    config::load(path)
 }
 
 fn build_relayer(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Webb Relayer does not provide much information when there is something wrong with the configuration files.

For example, missing one field on one of the files would result in a more generic error like:

`missing http-endpoint` but it won't tell you where, or which file.

## What is the new behavior?

Now we get more descriptive error messages:

Examples:
```
ERROR webb_relayer::config: evm.rinkeby: missing field `http-endpoint`
```
> Notice now it says the path of the error `evm.rinkeby`.

```
ERROR webb_relayer::config: evm.rinkeby.private-key: error while loading this env RINKEBY_PRIVATE_KEY: environment variable not found
```

```
ERROR webb_relayer::config: evm.rinkeby.private-key: Invalid input length
 got 0x<REDACTED> but expected a 66 chars string (including the 0x prefix) but found 65 char
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
