### PR TITLE
Include beneficiary ss58 address on substrate info call from suri config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use config::FileFormat;
 use ethereum_types::{Address, Secret, U256};
 use serde::{Deserialize, Serialize};
-use webb::substrate::subxt::sp_core::sr25519::{Pair as Sr25519Pair , Public};
+use webb::substrate::subxt::sp_core::sr25519::{Pair as Sr25519Pair, Public};
 use webb::substrate::subxt::sp_core::Pair;
 
 const fn default_port() -> u16 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use config::FileFormat;
 use ethereum_types::{Address, Secret, U256};
 use serde::{Deserialize, Serialize};
-use webb::substrate::subxt::sp_core::sr25519::Pair as Sr25519Pair;
+use webb::substrate::subxt::sp_core::sr25519::{Pair as Sr25519Pair , Public};
 use webb::substrate::subxt::sp_core::Pair;
 
 const fn default_port() -> u16 {
@@ -143,7 +143,7 @@ pub struct SubstrateConfig {
     #[serde(skip_serializing)]
     pub suri: Suri,
     /// Optionally, a user can specify an account to receive rewards for relaying
-    pub beneficiary: Option<Address>,
+    pub beneficiary: Option<Public>,
     /// Which Substrate Runtime to use?
     pub runtime: SubstrateRuntime,
     /// Supported pallets over this substrate node.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -34,6 +34,7 @@ use webb::substrate::subxt::{DefaultConfig};
 use webb::substrate::protocol_substrate_runtime::api::RuntimeApi;
 use crate::context::RelayerContext;
 use crate::store::LeafCacheStore;
+use webb::substrate::subxt::sp_core::Pair;
 
 type CommandStream = mpsc::Sender<CommandResponse>;
 
@@ -127,6 +128,14 @@ pub async fn handle_relayer_info(
             let key = SecretKey::from_bytes(v.private_key.as_bytes())?;
             let wallet = LocalWallet::from(key);
             v.beneficiary = Some(wallet.address());
+            Result::<_, anyhow::Error>::Ok(())
+        });
+    let _ = config
+        .substrate
+        .values_mut()
+        .filter(|v| v.beneficiary.is_none())
+        .try_for_each(|v| {
+            v.beneficiary = Some(v.suri.public());
             Result::<_, anyhow::Error>::Ok(())
         });
     Ok(warp::reply::json(&RelayerInformationResponse { config }))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Include beneficiary ss58 address on substrate info call
Issue Number: Closes #85 


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

The value of beneficiary for substrate config is `Some<Public>`

## Other information
