### PR TITLE
Update resource id to match new scheme

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-01-16"
+channel = "nightly-2022-01-25"
 components = ["rustfmt", "clippy"]
 targets = []

--- a/src/events_watcher/anchor_watcher_over_dkg.rs
+++ b/src/events_watcher/anchor_watcher_over_dkg.rs
@@ -14,11 +14,11 @@ use webb::substrate::subxt::sp_core::sr25519::Pair as Sr25519Pair;
 use webb::substrate::{dkg_runtime, subxt};
 
 use crate::config;
+use crate::events_watcher::ChainIdType;
 use crate::events_watcher::{
     create_resource_id, ProposalData, ProposalHeader, ProposalNonce,
 };
 use crate::store::sled::SledStore;
-
 type HttpProvider = providers::Provider<providers::Http>;
 
 pub struct AnchorWatcherWithSubstrate<R, C>
@@ -177,13 +177,16 @@ impl super::EventWatcher for AnchorWatcherOverDKG {
                 merkle_root: root,
             };
             let mut proposal_data = Vec::with_capacity(80);
-            let resource_id =
-                create_resource_id(data.anchor_address, dest_chain_id)?;
+            let resource_id = create_resource_id(
+                data.anchor_address,
+                ChainIdType::EVM(0),
+                dest_chain_id,
+            )?;
             tracing::trace!("r_id: 0x{}", hex::encode(&resource_id));
             let header = ProposalHeader {
                 resource_id,
                 function_sig,
-                chain_id: dest_chain_id.as_u32(),
+                chain_id: ChainIdType::EVM(dest_chain_id.as_u32()),
                 nonce: ProposalNonce::from(leaf_index),
             };
             // first the header (40 bytes)

--- a/src/events_watcher/bridge_watcher.rs
+++ b/src/events_watcher/bridge_watcher.rs
@@ -441,8 +441,8 @@ pub fn create_resource_id(
     chain_id: types::U256,
 ) -> anyhow::Result<[u8; 32]> {
     let chain_type_bytes = match chain_type {
-        ChainIdType::EVM(_) => [1u32,0],
-        ChainIdType::Substrate(_) => [2u32,0],
+        ChainIdType::EVM(_) => to_hex(1u32, 2),
+        ChainIdType::Substrate(_) => to_hex(2u32, 2),
         _ => panic!("Unknown chain type"),
     };
     let truncated = to_hex(chain_id, 4);

--- a/src/events_watcher/mod.rs
+++ b/src/events_watcher/mod.rs
@@ -492,6 +492,7 @@ pub trait SubstrateEventWatcher {
 pub type ResourceId = [u8; 32];
 pub type ProposalNonce = u64;
 
+#[allow(clippy::dead_code)]
 // TODO: Use the type from dkg-runtime-primitives or organize in another single location.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ChainIdType {

--- a/src/events_watcher/mod.rs
+++ b/src/events_watcher/mod.rs
@@ -492,7 +492,7 @@ pub trait SubstrateEventWatcher {
 pub type ResourceId = [u8; 32];
 pub type ProposalNonce = u64;
 
-#[allow(clippy::dead_code)]
+#[allow(dead_code)]
 // TODO: Use the type from dkg-runtime-primitives or organize in another single location.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ChainIdType {

--- a/src/events_watcher/mod.rs
+++ b/src/events_watcher/mod.rs
@@ -492,10 +492,27 @@ pub trait SubstrateEventWatcher {
 pub type ResourceId = [u8; 32];
 pub type ProposalNonce = u64;
 
-#[derive(Debug, Clone, Copy)]
+// TODO: Use the type from dkg-runtime-primitives or organize in another single location.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChainIdType {
+    // EVM(chain_identifier)
+    EVM(u32),
+    // Substrate(chain_identifier)
+    Substrate(u32),
+    // Relay chain(relay_chain_identifier, chain_identifier)
+    RelayChain(Vec<u8>, u32),
+    // Parachain(relay_chain_identifier, para_id)
+    Parachain(Vec<u8>, u32),
+    // Cosmos
+    CosmosSDK(u32),
+    // Solana
+    Solana(u32),
+}
+
+#[derive(Debug, Clone)]
 pub struct ProposalHeader {
     pub resource_id: ResourceId,
-    pub chain_id: u32,
+    pub chain_id: ChainIdType,
     pub function_sig: [u8; 4],
     pub nonce: ProposalNonce,
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR is related to:
- https://github.com/webb-tools/protocol-solidity/issues/108
- https://github.com/webb-tools/protocol-solidity/pull/109
- https://github.com/webb-tools/dkg-substrate/pull/123

This PR is updating the resource ID structure across the relayer so that the relayer adds contextual information to proposal headers that includes _what_ chain type the proposal is meant to execute on. We need to know this information to mutate unsigned proposal data in the DKG so that the DKG knows what proposal data to sign for which chain such as appending Ethereum signed message prefixes on EVM chains.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The resource IDs contain no information about what type of chain the proposal is meant to execute on.

Issue Number: https://github.com/webb-tools/protocol-solidity/issues/108


## What is the new behavior?
The resource ID format now contains information about what type of chain the proposal is meant to execute on.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No