### PR TITLE
Update anchor update proposal with target system bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4676,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "webb"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cea065330a36a4705bd16e9307c025a61a17b444f3275ed50ae6220f048af99"
+checksum = "620b4093e34ba171f91beec828a9af6a6b3027ede89be07d1b9f9d1247a51462"
 dependencies = [
  "async-trait",
  "ethers",
@@ -4695,8 +4695,9 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.2.3"
-source = "git+https://github.com/webb-tools/webb-rs?branch=drew/edge-metadata-update#5cf6b50b7382f513aecd3b476017d937b8cf3239"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989a673b719232a23f49327db2f2d816f5241ad4ad6b54cc6e45e896bd3c3e5b"
 dependencies = [
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4695,9 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389b12ef89eae07d5ee9f09068b418477ea0b5296b7e68f1ef9d70b8a1aedd73"
+version = "0.2.3"
+source = "git+https://github.com/webb-tools/webb-rs?branch=drew/edge-metadata-update#5cf6b50b7382f513aecd3b476017d937b8cf3239"
 dependencies = [
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,8 @@ hex = { version = "0.4", default-features = false }
 # just to make it compile on linux where the openssl is not available.
 # until ethers-rs solve this issue: https://github.com/gakonst/ethers-rs/issues/325
 native-tls = { version = "^0.2", features = ["vendored"] }
-webb = { version = "0.3.3", default-features = false }
-# webb-proposals = { version = "0.2.2", default-features = false, features = ["scale"] }
-webb-proposals = { git = "https://github.com/webb-tools/webb-rs", branch = "drew/edge-metadata-update", default-features = false, features = ["scale"] }
+webb = { version = "0.3.6", default-features = false }
+webb-proposals = { version = "0.2.4", default-features = false, features = ["scale"] }
 scale = { package = "parity-scale-codec", version = "2.3.0", default-features = false }
 ethereum-types = "0.12"
 thiserror = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ hex = { version = "0.4", default-features = false }
 # until ethers-rs solve this issue: https://github.com/gakonst/ethers-rs/issues/325
 native-tls = { version = "^0.2", features = ["vendored"] }
 webb = { version = "0.3.3", default-features = false }
-webb-proposals = { version = "0.2.2", default-features = false, features = ["scale"] }
+# webb-proposals = { version = "0.2.2", default-features = false, features = ["scale"] }
+webb-proposals = { git = "https://github.com/webb-tools/webb-rs", branch = "drew/edge-metadata-update", default-features = false, features = ["scale"] }
 scale = { package = "parity-scale-codec", version = "2.3.0", default-features = false }
 ethereum-types = "0.12"
 thiserror = "^1.0"

--- a/src/events_watcher/anchor_watcher.rs
+++ b/src/events_watcher/anchor_watcher.rs
@@ -182,6 +182,7 @@ where
                 webb_proposals::TypedChainId::Evm(src_chain_id.as_u32()),
                 leaf_index,
                 root,
+                target_system.into_fixed_bytes(),
             );
             let can_sign_proposal = self
                 .proposal_signing_backend

--- a/src/events_watcher/proposal_signing_backend/dkg.rs
+++ b/src/events_watcher/proposal_signing_backend/dkg.rs
@@ -82,6 +82,7 @@ impl DkgProposalSigningBackend<DkgRuntimeApi, DkgConfig> {
         proposal: &AnchorUpdateProposal,
     ) -> anyhow::Result<()> {
         let tx_api = self.api.tx().dkg_proposals();
+
         let leaf_index = proposal.latest_leaf_index();
         let resource_id = proposal.header().resource_id();
         let src_chain_id =

--- a/tests/package.json
+++ b/tests/package.json
@@ -25,6 +25,7 @@
     "@polkadot/api": "7.13.1",
     "@truffle/hdwallet-provider": "^2.0.3",
     "@webb-tools/protocol-solidity": "^0.1.12",
+    "@webb-tools/api": "0.1.4-46",
     "@webb-tools/sdk-core": "0.1.4-46",
     "JSONStream": "^1.3.5",
     "async-retry": "^1.3.3",

--- a/tests/test/evmTransactionRelayer.test.ts
+++ b/tests/test/evmTransactionRelayer.test.ts
@@ -25,7 +25,7 @@ import { LocalChain } from '../lib/localTestnet.js';
 import { calcualteRelayerFees, WebbRelayer } from '../lib/webbRelayer.js';
 import getPort, { portNumbers } from 'get-port';
 import { IAnchor } from '@webb-tools/interfaces';
-import { IAnchorDeposit } from '@webb-tools/interfaces/src/anchor/index';
+import { IAnchorDeposit } from '@webb-tools/interfaces/src/anchor';
 import { u8aToHex } from '@polkadot/util';
 
 describe('EVM Transaction Relayer', function () {

--- a/tests/test/substrate/anchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/anchorTransactionRelayer.test.ts
@@ -353,7 +353,7 @@ async function createAnchorDepositTx(api: ApiPromise): Promise<{
   //@ts-ignore
   const sorted = treeIds?.map(id => Number(id.toHuman()[0])).sort();
   //@ts-ignore
-  const treeId = sorted[0];
+  const treeId = sorted[0]!;
   const leaf = note.getLeaf();
   const tx = api.tx.anchorBn254!.deposit!(treeId, leaf);
   return { tx, note };
@@ -397,7 +397,7 @@ async function createAnchorWithdrawProof(
     //@ts-ignore
     const sorted = treeIds?.map(id => Number(id.toHuman()[0])).sort();
     //@ts-ignore
-    const treeId = sorted[0];
+    const treeId = sorted[0]!;
     //@ts-ignore
     const getLeaves = api.rpc.mt.getLeaves;
     const treeLeaves: Uint8Array[] = await getLeaves(treeId, 0, 511);

--- a/tests/test/substrate/anchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/anchorTransactionRelayer.test.ts
@@ -197,7 +197,7 @@ describe('Substrate Anchor Transaction Relayer', function () {
       expect(e).to.not.be.null;
       // Runtime Error that indicates invalid withdrawal proof
       expect(e).to.contain(
-        'Runtime error: RuntimeError(Module { index: 40, error: 1 }'
+        'Runtime error: RuntimeError(Module { index: 41, error: 2 }'
       );
     }
   });
@@ -257,7 +257,7 @@ describe('Substrate Anchor Transaction Relayer', function () {
       expect(e).to.not.be.null;
       // Runtime Error that indicates invalid withdrawal proof
       expect(e).to.contain(
-        'Runtime error: RuntimeError(Module { index: 40, error: 1 }'
+        'Runtime error: RuntimeError(Module { index: 41, error: 2 }'
       );
     }
   });
@@ -348,7 +348,12 @@ async function createAnchorDepositTx(api: ApiPromise): Promise<{
     exponentiation: '5',
   };
   const note = await Note.generateNote(noteInput);
-  const treeId = 5;
+  //@ts-ignore
+  const treeIds = await api.query.anchorBn254.anchors?.keys();
+  //@ts-ignore
+  const sorted = treeIds?.map(id => Number(id.toHuman()[0])).sort();
+  //@ts-ignore
+  const treeId = sorted[0];
   const leaf = note.getLeaf();
   const tx = api.tx.anchorBn254!.deposit!(treeId, leaf);
   return { tx, note };
@@ -387,14 +392,19 @@ async function createAnchorWithdrawProof(
       '0x',
       ''
     );
-    const treeId = 5;
+    //@ts-ignore
+    const treeIds = await api.query.anchorBn254.anchors?.keys();
+    //@ts-ignore
+    const sorted = treeIds?.map(id => Number(id.toHuman()[0])).sort();
+    //@ts-ignore
+    const treeId = sorted[0];
     //@ts-ignore
     const getLeaves = api.rpc.mt.getLeaves;
     const treeLeaves: Uint8Array[] = await getLeaves(treeId, 0, 511);
 
     // Get tree root on chain
     // @ts-ignore
-    const treeRoot = await api.query.merkleTreeBn254.trees(4);
+    const treeRoot = await api.query.merkleTreeBn254.trees(treeId);
 
     const pm = new ProvingManagerWrapper('direct-call');
     const leafHex = u8aToHex(note.getLeaf());

--- a/tests/test/substrate/anchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/anchorTransactionRelayer.test.ts
@@ -353,7 +353,7 @@ async function createAnchorDepositTx(api: ApiPromise): Promise<{
   //@ts-ignore
   const sorted = treeIds?.map(id => Number(id.toHuman()[0])).sort();
   //@ts-ignore
-  const treeId = sorted[0]!;
+  const treeId = sorted[0] || 5;
   const leaf = note.getLeaf();
   const tx = api.tx.anchorBn254!.deposit!(treeId, leaf);
   return { tx, note };
@@ -397,7 +397,7 @@ async function createAnchorWithdrawProof(
     //@ts-ignore
     const sorted = treeIds?.map(id => Number(id.toHuman()[0])).sort();
     //@ts-ignore
-    const treeId = sorted[0]!;
+    const treeId = sorted[0] || 5;
     //@ts-ignore
     const getLeaves = api.rpc.mt.getLeaves;
     const treeLeaves: Uint8Array[] = await getLeaves(treeId, 0, 511);

--- a/tests/test/substrate/anchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/anchorTransactionRelayer.test.ts
@@ -348,7 +348,7 @@ async function createAnchorDepositTx(api: ApiPromise): Promise<{
     exponentiation: '5',
   };
   const note = await Note.generateNote(noteInput);
-  const treeId = 4;
+  const treeId = 5;
   const leaf = note.getLeaf();
   const tx = api.tx.anchorBn254!.deposit!(treeId, leaf);
   return { tx, note };
@@ -387,7 +387,7 @@ async function createAnchorWithdrawProof(
       '0x',
       ''
     );
-    const treeId = 4;
+    const treeId = 5;
     //@ts-ignore
     const getLeaves = api.rpc.mt.getLeaves;
     const treeLeaves: Uint8Array[] = await getLeaves(treeId, 0, 511);

--- a/tests/test/substrate/mixerTransactionRelayer.test.ts
+++ b/tests/test/substrate/mixerTransactionRelayer.test.ts
@@ -13,7 +13,7 @@ import { LocalProtocolSubstrate } from '../../lib/localProtocolSubstrate.js';
 import { UsageMode } from '../../lib/substrateNodeBase.js';
 import { ApiPromise, Keyring } from '@polkadot/api';
 import { u8aToHex, hexToU8a } from '@polkadot/util';
-import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { ModuleErrors, SubmittableExtrinsic } from '@polkadot/api/types';
 import { decodeAddress } from '@polkadot/util-crypto';
 import {
   Note,

--- a/tests/test/substrate/mixerTransactionRelayer.test.ts
+++ b/tests/test/substrate/mixerTransactionRelayer.test.ts
@@ -22,7 +22,7 @@ import {
   ProvingManagerWrapper,
 } from '@webb-tools/sdk-core';
 
-describe('Substrate Transaction Relayer', function () {
+describe('Substrate Mixer Transaction Relayer', function () {
   const tmpDirPath = temp.mkdirSync();
   let aliceNode: LocalProtocolSubstrate;
   let bobNode: LocalProtocolSubstrate;


### PR DESCRIPTION
# Overview
This PR updates the anchor update metadata proposals with the target system as a 32-byte value. This change is primarily geared with saving even more information about edges so that end-user applications can rely on less external configuration. This is done by adding the contract addresses / tree ids we're bridging

## Related:
- [webb-rs](https://github.com/webb-tools/webb-rs/pull/31)
- [protocol-solidity](https://github.com/webb-tools/protocol-solidity/pull/142/)
- [protocol-substrate](https://github.com/webb-tools/protocol-substrate/pull/191)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
