### PR TITLE
Fix encrypted output to be unbounded & Serde camel case

### DIFF
--- a/config/development/evm-localnet/athena.toml
+++ b/config/development/evm-localnet/athena.toml
@@ -48,12 +48,12 @@ size = 1
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [
@@ -71,8 +71,7 @@ address = "0x3d3955aAe5Bdf9E6547A140Baad4BC57Fa4EBA17"
 deployed-at = 1
 size = 0.01
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-withdraw-fee-percentage = 0
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 linked-anchors = [
   { chain = "hermes", address = "0xaC361518Bb9535D0E3172DC45a4e56d71a7FDFc4" },
   { chain = "demeter", address = "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"},
@@ -85,8 +84,7 @@ address = "0xFEe587E68c470DAE8147B46bB39fF230A29D4769"
 deployed-at = 1
 size = 0.01
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-withdraw-fee-percentage = 0
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 linked-anchors = [
   { chain = "hermes", address = "0xb824C5F99339C7E486a1b452B635886BE82bc8b7" },
   { chain = "demeter", address = "0xdB587ef6aaA16b5719CDd3AaB316F0E70473e9Be"},

--- a/config/development/evm-localnet/demeter.toml
+++ b/config/development/evm-localnet/demeter.toml
@@ -47,12 +47,7 @@ size = 1
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [
@@ -70,8 +65,7 @@ address = "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
 deployed-at = 1
 size = 0.01
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-withdraw-fee-percentage = 0
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 linked-anchors = [
   { chain = "hermes", address = "0xaC361518Bb9535D0E3172DC45a4e56d71a7FDFc4" },
   { chain = "athena", address = "0x3d3955aAe5Bdf9E6547A140Baad4BC57Fa4EBA17" },
@@ -84,8 +78,7 @@ address = "0xdB587ef6aaA16b5719CDd3AaB316F0E70473e9Be"
 deployed-at = 1
 size = 0.01
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-withdraw-fee-percentage = 0
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 linked-anchors = [
   { chain = "hermes", address = "0xb824C5F99339C7E486a1b452B635886BE82bc8b7" },
   { chain = "athena", address = "0xFEe587E68c470DAE8147B46bB39fF230A29D4769"},

--- a/config/development/evm-localnet/hermes.toml
+++ b/config/development/evm-localnet/hermes.toml
@@ -47,12 +47,12 @@ size = 1
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [
@@ -70,8 +70,7 @@ address = "0xaC361518Bb9535D0E3172DC45a4e56d71a7FDFc4"
 deployed-at = 1
 size = 0.01
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-withdraw-fee-percentage = 0
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 linked-anchors = [
   { chain = "athena", address = "0x3d3955aAe5Bdf9E6547A140Baad4BC57Fa4EBA17" },
   { chain = "demeter", address = "0x91eB86019FD8D7c5a9E31143D422850A13F670A3" },
@@ -84,8 +83,7 @@ address = "0xb824C5F99339C7E486a1b452B635886BE82bc8b7"
 deployed-at = 1
 size = 0.01
 events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }
-withdraw-fee-percentage = 0
-withdraw-gaslimit = "0x350000"
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 linked-anchors = [
   { chain = "athena", address = "0xFEe587E68c470DAE8147B46bB39fF230A29D4769" },
   { chain = "demeter", address = "0xdB587ef6aaA16b5719CDd3AaB316F0E70473e9Be"},

--- a/config/development/local-substrate/substrate.toml
+++ b/config/development/local-substrate/substrate.toml
@@ -2,8 +2,10 @@ port = 9955
 
 [substrate.localnode]
 enabled=true
-http-endpoint = "http://localhost:9933/"
-ws-endpoint = "ws://localhost:9944/"
+http-endpoint = "http://localhost:9944"
+ws-endpoint = "ws://localhost:9944"
 runtime = "WebbProtocol"
 suri = "//Alice//stash"
-pallets = []
+[[substrate.localnode.pallets]]
+pallet = "VAnchorBn254"
+events-watcher = { enabled = true ,polling-interval = 10000 , print-progress-interval = 0}

--- a/config/development/local-substrate/substrate.toml
+++ b/config/development/local-substrate/substrate.toml
@@ -8,4 +8,4 @@ runtime = "WebbProtocol"
 suri = "//Alice//stash"
 [[substrate.localnode.pallets]]
 pallet = "VAnchorBn254"
-events-watcher = { enabled = true ,polling-interval = 10000 , print-progress-interval = 0}
+events-watcher = { enabled = true, polling-interval = 10000, print-progress-interval = 0 }

--- a/config/development/local-substrate/substrate.toml
+++ b/config/development/local-substrate/substrate.toml
@@ -2,7 +2,7 @@ port = 9955
 
 [substrate.localnode]
 enabled=true
-http-endpoint = "http://localhost:9944"
+http-endpoint = "http://localhost:9933"
 ws-endpoint = "ws://localhost:9944"
 runtime = "WebbProtocol"
 suri = "//Alice//stash"

--- a/config/exclusive-strategies/8sided-evm-bridge/arbitrum_test.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/arbitrum_test.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/goerli.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/goerli.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/kovan.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/kovan.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/moonbase.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/moonbase.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/optimism_test.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/optimism_test.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/polygon_test.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/polygon_test.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/rinkeby.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/rinkeby.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/config/exclusive-strategies/8sided-evm-bridge/ropsten.toml
+++ b/config/exclusive-strategies/8sided-evm-bridge/ropsten.toml
@@ -50,11 +50,12 @@ size = 0.01
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.
 events-watcher = { enabled = true, polling-interval = 15000 }
-# Configuration for private transaction relaying which determines the fee taken by this relayer 
-withdraw-fee-percentage = 0
-# Value for private transaction relaying which specifies the maximum amount of gas which will be
-# used when submitting a withdraw transaction
-withdraw-gaslimit = "0x350000"
+# Configuration related to withdraw (for private transaction relaying)
+#    - withdraw-gasLimit: Value which specifies the maximum amount of gas which will be used when
+#                         submitting a withdraw transaction
+#    - withdraw-fee-percentage: Value which specifies the fees that this relayer will collect upon
+#                               submitting a withdraw transaction
+withdraw-config = { withdraw-fee-percentage = 0, withdraw-gaslimit = "0x350000" }
 # Entries for this anchor contract's connected edges.
 # These fields are used to determine the generation of AnchorUpdate proposals
 linked-anchors = [

--- a/src/tx_relay/evm/vanchor.rs
+++ b/src/tx_relay/evm/vanchor.rs
@@ -159,16 +159,8 @@ pub async fn handle_vanchor_relay_tx<'a>(
         relayer: cmd.ext_data.relayer,
         fee: cmd.ext_data.fee,
         ext_amount: cmd.ext_data.ext_amount,
-        encrypted_output_1: cmd
-            .ext_data
-            .encrypted_output1
-            .to_fixed_bytes()
-            .into(),
-        encrypted_output_2: cmd
-            .ext_data
-            .encrypted_output2
-            .to_fixed_bytes()
-            .into(),
+        encrypted_output_1: cmd.ext_data.encrypted_output1,
+        encrypted_output_2: cmd.ext_data.encrypted_output2,
     };
 
     let proof = Proof {

--- a/src/tx_relay/mod.rs
+++ b/src/tx_relay/mod.rs
@@ -57,6 +57,7 @@ pub struct AnchorRelayTransaction<Id, P, R, E, I, B> {
 
 /// Proof data object for VAnchor proofs on any chain
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProofData<P, R, E> {
     /// Encoded proof
     pub proof: P,
@@ -74,6 +75,7 @@ pub struct ProofData<P, R, E> {
 
 /// External data for the VAnchor on any chain.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExtData<E, I, B, A> {
     /// Recipient identifier of the withdrawn funds
     pub recipient: I,
@@ -100,5 +102,5 @@ pub struct VAnchorRelayTransaction<Id, P, R, E, I, B, A> {
     /// The zero-knowledge proof data structure for VAnchor transactions
     pub proof_data: ProofData<P, R, E>,
     /// The external data structure for arbitrary inputs
-    pub ext_data: ExtData<E, I, B, A>,
+    pub ext_data: ExtData<P, I, B, A>,
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
- `ExtData`  encrypted output fields are bounded however for protocol substrate node now they are unbounded
- `ExtData` , `ProofData` missing the serde  `#[serde(rename_all = "camelCase")]`, Thus the webbsocket payload isn't in camel case
Issue Number: N/A


## What is the new behavior?
- Fix the `ExtData`
- Camel casing the WebSocket payload keys for transaction relaying

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No



## Other information
`ExtData.encrypted_output1` ,and `ExtData.encrypted_output2` follow the smae type as the Proof `Bytes` for evm ,and `Vec<u8>` for substrate 
