### PR TITLE
Update webb-rs to v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,9 +4798,9 @@ dependencies = [
 
 [[package]]
 name = "webb"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f79bf4cba7ad848dd481d5d5fa9f903e314337fba777b647f77e7c2458cd5"
+checksum = "fe0eb1d565f5b0b25335e8c6484270f6db4fe184182f4cc721f2de6bc8f33cdd"
 dependencies = [
  "async-trait",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hex = { version = "0.4", default-features = false }
 # just to make it compile on linux where the openssl is not available.
 # until ethers-rs solve this issue: https://github.com/gakonst/ethers-rs/issues/325
 native-tls = { version = "^0.2", features = ["vendored"] }
-webb = { version = "0.4.2", default-features = false }
+webb = { version = "0.4.3", default-features = false }
 webb-proposals = { version = "0.3.4", default-features = false, features = ["scale"] }
 ethereum-types = "0.12"
 thiserror = "^1.0"

--- a/tests/test/substrate/signatureBridgeAnchor.test.ts
+++ b/tests/test/substrate/signatureBridgeAnchor.test.ts
@@ -155,7 +155,7 @@ describe('Substrate Signature Bridge Relaying On Anchor Deposit <> Mocked Backen
       api,
       PK1,
       treeId,
-      chainId,
+      chainId
     );
     const txSigned = await setResourceIdProposalCall.signAsync(account);
     await aliceNode.executeTransaction(txSigned);


### PR DESCRIPTION
## Summary of changes
- Update `webb-rs` (Webb SDK) to v0.4.3
- Fixes the failing tests in the CI (was due to old runtime bindings)


### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [x] Tested
- [ ] Documented
