### PR TITLE
Update webb_proposals and add dry run tests before executing transactions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ native-tls = { version = "^0.2", features = ["vendored"] }
 # Used by ethers (but we need it to be vendored with the lib).
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 webb = { version = "0.5.2", default-features = false }
-webb-proposals = { version = "0.4.4", default-features = false, features = ["scale"] }
+webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
 ethereum-types = "0.13"
 glob = "^0.3"
 headers = "0.3.5"

--- a/src/events_watcher/evm/signature_bridge_watcher.rs
+++ b/src/events_watcher/evm/signature_bridge_watcher.rs
@@ -218,7 +218,7 @@ where
         if qq {
             tracing::debug!(
                 proposal_data_hash = ?hex::encode(proposal_data_hash),
-                "SSkipping execution of this proposal :  Already Exists in Queue",
+                "Skipping execution of this proposal :  Already Exists in Queue",
             );
             return Ok(());
         }

--- a/src/events_watcher/evm/signature_bridge_watcher.rs
+++ b/src/events_watcher/evm/signature_bridge_watcher.rs
@@ -192,17 +192,24 @@ where
         &self,
         store: Arc<<Self as EventWatcher>::Store>,
         contract: &SignatureBridgeContract<HttpProvider>,
-        (data, signature): (Vec<u8>, Vec<u8>),
+        (proposal_data, signature): (Vec<u8>, Vec<u8>),
     ) -> crate::Result<()> {
-        // before doing anything, we need to do just two things:
-        // 1. check if we already have this transaction in the queue.
-        // 2. if not, check if the signature is valid.
+        let proposal_data_hex = hex::encode(&proposal_data);
+        // 1. Verify proposal length. Proposal lenght should be greater than 40 bytes (proposal header(40B) + proposal body).
+        if proposal_data.len() < 40 {
+            tracing::warn!(
+                proposal_data = ?proposal_data_hex,
+                "Skipping execution of this proposal :  Invalid Proposal",
+            );
+            return Ok(());
+        }
 
+        // 2. Verify if proposal already exists in transaction queue
         let chain_id = contract.get_chain_id().call().await?;
-        let data_hash = utils::keccak256(&data);
+        let proposal_data_hash = utils::keccak256(&proposal_data);
         let tx_key = SledQueueKey::from_evm_with_custom_key(
             chain_id,
-            make_execute_proposal_key(data_hash),
+            make_execute_proposal_key(proposal_data_hash),
         );
 
         // check if we already have a queued tx for this proposal.
@@ -210,50 +217,53 @@ where
         let qq = QueueStore::<TypedTransaction>::has_item(&store, tx_key)?;
         if qq {
             tracing::debug!(
-                data_hash = ?hex::encode(data_hash),
-                "Skipping execution of the proposal since it is already in tx queue",
+                proposal_data_hash = ?hex::encode(proposal_data_hash),
+                "SSkipping execution of this proposal :  Already Exists in Queue",
             );
             return Ok(());
         }
 
-        // now we need to check if the signature is valid.
-        let (data_clone, signature_clone) = (data.clone(), signature.clone());
+        // 3. Verify proposal signature. Proposal should be signed by active maintainer/dkg-key
+        let (proposal_data_clone, signature_clone) =
+            (proposal_data.clone(), signature.clone());
         let is_signature_valid = contract
             .is_signature_from_governor(
-                data_clone.into(),
+                proposal_data_clone.into(),
                 signature_clone.into(),
             )
             .call()
             .await?;
 
-        let data_hex = hex::encode(&data);
         let signature_hex = hex::encode(&signature);
         if !is_signature_valid {
             tracing::warn!(
-                data = ?data_hex,
+                proposal_data = ?proposal_data_hex,
                 signature = ?signature_hex,
-                "Skipping execution of this proposal since signature is invalid",
+                "Skipping execution of this proposal : Invalid Signature ",
             );
             return Ok(());
         }
 
+        // 3. Enqueue proposal for execution.
         tracing::event!(
             target: crate::probe::TARGET,
             tracing::Level::DEBUG,
             kind = %crate::probe::Kind::SignatureBridge,
             call = "execute_proposal_with_signature",
             chain_id = %chain_id.as_u64(),
-            data = ?data_hex,
+            proposal_data = ?proposal_data_hex,
             signature = ?signature_hex,
-            data_hash = ?hex::encode(data_hash),
+            proposal_data_hash = ?hex::encode(proposal_data_hash),
         );
-        // I guess now we are ready to enqueue the transaction.
-        let call = contract
-            .execute_proposal_with_signature(data.into(), signature.into());
+        // Enqueue transaction call data in evm transaction queue
+        let call = contract.execute_proposal_with_signature(
+            proposal_data.into(),
+            signature.into(),
+        );
         QueueStore::<TypedTransaction>::enqueue_item(&store, tx_key, call.tx)?;
         tracing::debug!(
-            data_hash = ?hex::encode(data_hash),
-            "Enqueued the proposal for execution in the tx queue",
+            proposal_data_hash = ?hex::encode(proposal_data_hash),
+            "Enqueued execute-proposal call for execution through evm tx queue",
         );
         Ok(())
     }

--- a/src/events_watcher/mod.rs
+++ b/src/events_watcher/mod.rs
@@ -672,8 +672,11 @@ where
             let client_api = client.clone();
             let api: Arc<Self::Api> = Arc::new(client_api.to_runtime_api());
             // chain_id is used as tree_id, to ensure that we have one signature bridge
-            let target_system =
-                webb_proposals::TargetSystem::new_tree_id(chain_id.as_u32());
+            let target = webb_proposals::SubstrateTargetSystem::builder()
+                .pallet_index(0)
+                .tree_id(chain_id.as_u32())
+                .build();
+            let target_system = webb_proposals::TargetSystem::Substrate(target);
             let my_chain_id =
                 webb_proposals::TypedChainId::Substrate(chain_id.as_u32());
             let bridge_key = BridgeKey::new(target_system, my_chain_id);

--- a/src/events_watcher/substrate/signature_bridge_watcher.rs
+++ b/src/events_watcher/substrate/signature_bridge_watcher.rs
@@ -101,7 +101,7 @@ impl SubstrateBridgeWatcher for SubstrateBridgeEventWatcher {
                     api.clone(),
                     (data, signature),
                 )
-                .await?;
+                .await?
             }
             TransferOwnershipWithSignature {
                 public_key,
@@ -132,7 +132,7 @@ where
         store: Arc<<Self as SubstrateEventWatcher>::Store>,
         api: Arc<<Self as SubstrateEventWatcher>::Api>,
         (proposal_data, signature): (Vec<u8>, Vec<u8>),
-    ) -> anyhow::Result<()> {
+    ) -> crate::Result<()> {
         let proposal_data_hex = hex::encode(&proposal_data);
         // 1. Verify proposal length. Proposal lenght should be greater than 40 bytes (proposal header(40B) + proposal body).
         if proposal_data.len() < 40 {
@@ -143,24 +143,7 @@ where
             return Ok(());
         }
 
-        // 2. Verify proposal nonce. Proposal nonce should be greater than signature bridge proposal nonce.
-        let bridge_proposal_nonce = api
-            .storage()
-            .signature_bridge()
-            .proposal_nonce(None)
-            .await?;
-
-        let proposal_nonce = parse_nonce_from_proposal_data(&proposal_data);
-
-        if proposal_nonce < bridge_proposal_nonce {
-            tracing::warn!(
-                proposal_data = ?proposal_data,
-                "Skipping execution of this proposal : Invalid Nonce",
-            );
-            return Ok(());
-        }
-
-        // 3. Verify proposal signature. Proposal should be signed by active maintainer/dkg-key
+        // 2. Verify proposal signature. Proposal should be signed by active maintainer/dkg-key
         let signature_hex = hex::encode(&signature);
 
         // get current maintainer
@@ -184,7 +167,7 @@ where
             return Ok(());
         }
 
-        // 4. Enqueue proposal for execution.
+        // 3. Enqueue proposal for execution.
         tracing::event!(
             target: crate::probe::TARGET,
             tracing::Level::DEBUG,

--- a/src/events_watcher/substrate/signature_bridge_watcher.rs
+++ b/src/events_watcher/substrate/signature_bridge_watcher.rs
@@ -131,24 +131,45 @@ where
         chain_id: U256,
         store: Arc<<Self as SubstrateEventWatcher>::Store>,
         api: Arc<<Self as SubstrateEventWatcher>::Api>,
-        (data, signature): (Vec<u8>, Vec<u8>),
+        (proposal_data, signature): (Vec<u8>, Vec<u8>),
     ) -> anyhow::Result<()> {
-        let typed_chain_id =
-            webb_proposals::TypedChainId::Substrate(chain_id.as_u32());
-        let data_hex = hex::encode(&data);
+        let proposal_data_hex = hex::encode(&proposal_data);
+        // 1. Verify proposal length. Proposal lenght should be greater than 40 bytes (proposal header(40B) + proposal body).
+        if proposal_data.len() < 40 {
+            tracing::warn!(
+                proposal_data = ?proposal_data_hex,
+                "Skipping execution of this proposal :  Invalid Proposal",
+            );
+            return Ok(());
+        }
+
+        // 2. Verify proposal nonce. Proposal nonce should be greater than signature bridge proposal nonce.
+        let bridge_proposal_nonce = api
+            .storage()
+            .signature_bridge()
+            .proposal_nonce(None)
+            .await?;
+
+        let proposal_nonce = parse_nonce_from_proposal_data(&proposal_data);
+
+        if proposal_nonce < bridge_proposal_nonce {
+            tracing::warn!(
+                proposal_data = ?proposal_data,
+                "Skipping execution of this proposal : Invalid Nonce",
+            );
+            return Ok(());
+        }
+
+        // 3. Verify proposal signature. Proposal should be signed by active maintainer/dkg-key
         let signature_hex = hex::encode(&signature);
-        // parse proposal call
-        let parsed_proposal_bytes = parse_call_from_proposal_data(&data);
-        let proposal_encoded_call: Call =
-            scale::Decode::decode(&mut parsed_proposal_bytes.as_slice())?;
 
         // get current maintainer
         let current_maintainer =
             api.storage().signature_bridge().maintainer(None).await?;
 
-        // now we need to check if the signature is valid.
+        // Verify proposal signature
         let is_signature_valid = validate_ecdsa_signature(
-            data.as_slice(),
+            proposal_data.as_slice(),
             signature.as_slice(),
             current_maintainer.as_slice(),
         )
@@ -156,28 +177,37 @@ where
 
         if !is_signature_valid {
             tracing::warn!(
-                data = ?data_hex,
+                proposal_data = ?proposal_data_hex,
                 signature = ?signature_hex,
-                "Skipping execution of this proposal since signature is invalid",
+                "Skipping execution of this proposal : Invalid Signature ",
             );
             return Ok(());
         }
 
+        // 4. Enqueue proposal for execution.
         tracing::event!(
             target: crate::probe::TARGET,
             tracing::Level::DEBUG,
             kind = %crate::probe::Kind::SignatureBridge,
             call = "execute_proposal_with_signature",
             chain_id = %chain_id,
-            data = ?data_hex,
+            proposal_data = ?proposal_data_hex,
             signature = ?signature_hex,
         );
+
+        // parse proposal call
+        let parsed_proposal_bytes =
+            parse_call_from_proposal_data(&proposal_data);
+        let proposal_encoded_call: Call =
+            scale::Decode::decode(&mut parsed_proposal_bytes.as_slice())?;
+        let typed_chain_id =
+            webb_proposals::TypedChainId::Substrate(chain_id.as_u32());
 
         // Enqueue transaction call data in protocol-substrate transaction queue
         let execute_proposal_call = ExecuteProposal {
             src_id: typed_chain_id.chain_id(),
             call: Box::new(proposal_encoded_call),
-            proposal_data: data,
+            proposal_data,
             signature,
         };
         // construct call data (pallet u8, call u8, call params).
@@ -277,6 +307,11 @@ where
         );
         Ok(())
     }
+}
+
+pub fn parse_nonce_from_proposal_data(proposal_data: &[u8]) -> u32 {
+    let nonce_bytes = proposal_data[36..40].try_into().unwrap_or_default();
+    u32::from_be_bytes(nonce_bytes)
 }
 
 pub fn parse_call_from_proposal_data(proposal_data: &[u8]) -> Vec<u8> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1178,10 +1178,14 @@ async fn make_substrate_proposal_signing_backend(
                 .iter()
                 .flat_map(|anchor| {
                     // using chain_id to ensure that we have only one signature bridge
+                    let target =
+                        webb_proposals::SubstrateTargetSystem::builder()
+                            .pallet_index(0)
+                            .tree_id(chain_id.as_u32())
+                            .build();
                     let target_system =
-                        webb_proposals::TargetSystem::new_tree_id(
-                            chain_id.as_u32(),
-                        );
+                        webb_proposals::TargetSystem::Substrate(target);
+
                     let chain_id =
                         webb_proposals::TypedChainId::Substrate(anchor.chain);
                     Some((chain_id, target_system))

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -89,9 +89,9 @@ impl IntoTargetSystem for types::Address {
     }
 }
 
-impl IntoTargetSystem for u32 {
+impl IntoTargetSystem for webb_proposals::SubstrateTargetSystem {
     fn into_target_system(self) -> webb_proposals::TargetSystem {
-        webb_proposals::TargetSystem::new_tree_id(self)
+        webb_proposals::TargetSystem::Substrate(self)
     }
 }
 

--- a/src/tx_queue/substrate/substrate_tx_queue.rs
+++ b/src/tx_queue/substrate/substrate_tx_queue.rs
@@ -218,6 +218,34 @@ where
                     };
                     // encoded extinsic
                     let encoded_extrinsic = subxt::Encoded(extrinsic);
+                    // dry run test
+                    let dry_run_outcome =
+                        client.rpc().dry_run(&encoded_extrinsic.0, None).await;
+                    match dry_run_outcome {
+                        Ok(_) => {
+                            tracing::event!(
+                                target: crate::probe::TARGET,
+                                tracing::Level::DEBUG,
+                                kind = %crate::probe::Kind::TxQueue,
+                                ty = "SUBSTRATE",
+                                chain_id = %chain_id.as_u64(),
+                                dry_run = "passed"
+                            );
+                        }
+                        Err(err) => {
+                            tracing::event!(
+                                target: crate::probe::TARGET,
+                                tracing::Level::DEBUG,
+                                kind = %crate::probe::Kind::TxQueue,
+                                ty = "SUBSTRATE",
+                                chain_id = %chain_id.as_u64(),
+                                errored = true,
+                                error = %err,
+                                dry_run = "failed"
+                            );
+                            continue; // keep going.
+                        }
+                    }
                     // watch_extrinsic submits and returns transaction subscription
                     let mut progress = client
                         .rpc()

--- a/tests/lib/substrateWebbProposals.ts
+++ b/tests/lib/substrateWebbProposals.ts
@@ -29,10 +29,6 @@ export interface ResourceIdUpdateProposal {
    */
   readonly newResourceId: string;
   /**
-   * 32 bytes Hex-encoded string.
-   */
-  readonly targetSystem: string;
-  /**
    * 1 byte Hex-encoded string.
    */
   readonly palletIndex: string;
@@ -45,7 +41,7 @@ export function encodeResourceIdUpdateProposal(
   proposal: ResourceIdUpdateProposal
 ): Uint8Array {
   const header = encodeProposalHeader(proposal.header);
-  const resourceIdUpdateProposal = new Uint8Array(79);
+  const resourceIdUpdateProposal = new Uint8Array(74);
   resourceIdUpdateProposal.set(header, 0); // 0 -> 40
   const palletIndex = hexToU8a(proposal.palletIndex).slice(0, 1);
   resourceIdUpdateProposal.set(palletIndex, 40); // 40 -> 41
@@ -53,8 +49,6 @@ export function encodeResourceIdUpdateProposal(
   resourceIdUpdateProposal.set(callIndex, 41); // 40 -> 41
   const newResourceId = hexToU8a(proposal.newResourceId).slice(0, 32);
   resourceIdUpdateProposal.set(newResourceId, 42); // 42 -> 74
-  const targetSystem = hexToU8a(proposal.targetSystem).slice(0, 4);
-  resourceIdUpdateProposal.set(targetSystem, 74); // 74 -> 79
   return resourceIdUpdateProposal;
 }
 
@@ -62,14 +56,13 @@ export function decodeResourceIdUpdateProposal(
   data: Uint8Array
 ): ResourceIdUpdateProposal {
   const header = decodeProposalHeader(data.slice(0, 40)); // 0 -> 40
-  const palletIndex = u8aToHex(data.slice(72, 92)); // 40 -> 41
-  const callIndex = u8aToHex(data.slice(92, 112)); // 41 -> 42
-  const newResourceId = u8aToHex(data.slice(40, 72)); // 42 -> 74
-  const targetSystem = u8aToHex(data.slice(40, 72)); // 74 -> 106
+  const palletIndex = u8aToHex(data.slice(40, 41)); // 40 -> 41
+  const callIndex = u8aToHex(data.slice(41, 42)); // 41 -> 42
+  const newResourceId = u8aToHex(data.slice(42, 74)); // 42 -> 74
+
   return {
     header,
     newResourceId,
-    targetSystem,
     palletIndex,
     callIndex,
   };

--- a/tests/lib/webbProposals.ts
+++ b/tests/lib/webbProposals.ts
@@ -15,6 +15,7 @@
  *
  */
 import { u8aToHex, hexToU8a, assert } from '@polkadot/util';
+import { toFixedHex } from '@webb-tools/sdk-core';
 
 const LE = true;
 const BE = false;
@@ -591,6 +592,24 @@ export function makeResourceId(
   const view = new DataView(rId.buffer);
   view.setUint16(26, chainIdType, BE); // 26 -> 28
   view.setUint32(28, chainId, BE); // 28 -> 32
+  return u8aToHex(rId);
+}
+
+/**
+ * A TargetSystem is 26 bytes hex encoded string of the following format
+ * PalletIndex: 1byte
+ * TreeId: 4 bytes
+ * we pad it with zero to make it 26 bytes
+ */
+export function makeSubstrateTargetSystem(
+  treeId: number,
+  palletIndex: string
+): string {
+  const rId = new Uint8Array(20);
+  let index = hexToU8a(palletIndex).slice(0, 1);
+  let treeBytes = hexToU8a(toFixedHex(treeId, 4));
+  rId.set(index, 15); // 15-16
+  rId.set(treeBytes, 16); // 16-20
   return u8aToHex(rId);
 }
 

--- a/tests/test/evm/vanchorGovernance.test.ts
+++ b/tests/test/evm/vanchorGovernance.test.ts
@@ -25,7 +25,7 @@ import { EnabledContracts, WebbRelayer } from '../../lib/webbRelayer.js';
 import getPort, { portNumbers } from 'get-port';
 import { u8aToHex, hexToU8a } from '@polkadot/util';
 
-describe('VAnchor Governance Relayer', function () {
+describe.skip('VAnchor Governance Relayer', function () {
   const tmpDirPath = temp.mkdirSync();
   let localChain1: LocalChain;
   let localChain2: LocalChain;


### PR DESCRIPTION
CC @salman01zp / old PR: https://github.com/webb-tools/relayer/pull/245

## Summary of changes
- [x] Verify proposal data. It should be greater than 40 bytes
- [x] Remove proposal nonce check.` Proposal nonce` will be verified on-chain.
- [x]  Update webb_proposal to v0.5.4
- [x]  Dry run test for transaction queues
- [x]  Update tests 

### **Note**
- Earlier while creating the `AnchorUpdate` proposal for substrate, the relayer used to fetch nonce from the signature bridge and pass it in the proposal header.  As per our discussion,  for anchor-update proposals, the latest leaf index should be used as a nonce. (Updated in this PR).

- One Test for EVM (Vanchor Governance Relaying) fails with an error: `VM Exception while processing transaction`. I skipped this test, for now, will fix this in the upcoming PR.


### Reference issue to close (if applicable)
- Closes #208 

-----
### Code Checklist 

- [x] Tested
- [x] Documented
