### PR TITLE
Fix Failing Substrate Vanchor Test

### DIFF
--- a/tests/test/substrate/vanchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/vanchorTransactionRelayer.test.ts
@@ -184,6 +184,7 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
     const decodedAddress = decodeAddress(address);
     const { encrypted: comEnc1 } = naclEncrypt(output1.commitment, secret);
     const { encrypted: comEnc2 } = naclEncrypt(output2.commitment, secret);
+    const assetId = new Uint8Array([254, 255, 255, 255]);
 
     const setup: ProvingManagerSetupInput<'vanchor'> = {
       chainId: outputChainId.toString(),
@@ -200,7 +201,7 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
       extAmount: extAmount.toString(),
       fee: fee.toString(),
       refund: '0',
-      token: decodedAddress,
+      token: assetId,
     };
 
     const data = (await provingManager.prove('vanchor', setup)) as VAnchorProof;
@@ -209,7 +210,7 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
       recipient: address,
       fee,
       refund: '0',
-      token: decodedAddress,
+      token: assetId,
       extAmount: extAmount,
       encryptedOutput1: u8aToHex(comEnc1),
       encryptedOutput2: u8aToHex(comEnc2),


### PR DESCRIPTION
## Summary of changes
- This PR slight change includes asset id as the token for `ext_data` in protocol substrate vanchor test