### PR TITLE
Encrypted output watcher for substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5866,26 +5866,9 @@ dependencies = [
 
 [[package]]
 name = "webb"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8325dbd9a62106bd5c13609431a254ba2dc554b33b57d673def2ea8c7a2ef81d"
-dependencies = [
- "async-trait",
- "ethers",
- "hex",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "serde_json",
- "subxt",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "webb"
 version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04df3acc4b053a011a0077fc75354499fe355a1e083b1ab1b0fb5328435c463c"
 dependencies = [
  "async-trait",
  "ethers",
@@ -5916,7 +5899,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "webb 0.5.7",
+ "webb",
  "webb-relayer",
  "webb-relayer-config",
  "webb-relayer-store",
@@ -5967,7 +5950,7 @@ dependencies = [
  "url",
  "warp",
  "warp-real-ip",
- "webb 0.5.10",
+ "webb",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
@@ -5992,7 +5975,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.16",
  "url",
- "webb 0.5.7",
+ "webb",
  "webb-proposals",
  "webb-relayer-store",
  "webb-relayer-types",
@@ -6010,7 +5993,7 @@ dependencies = [
  "sled",
  "tempfile",
  "tracing",
- "webb 0.5.7",
+ "webb",
  "webb-proposals",
  "webb-relayer-utils",
 ]
@@ -6026,7 +6009,7 @@ dependencies = [
  "tiny-keccak",
  "tracing",
  "url",
- "webb 0.5.7",
+ "webb",
 ]
 
 [[package]]
@@ -6043,7 +6026,7 @@ dependencies = [
  "thiserror",
  "url",
  "warp",
- "webb 0.5.7",
+ "webb",
  "webb-proposals",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5884,6 +5884,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "webb"
+version = "0.5.10"
+dependencies = [
+ "async-trait",
+ "ethers",
+ "hex",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "subxt",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "webb-block-poller"
 version = "0.1.0"
 dependencies = [
@@ -5899,7 +5916,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "webb",
+ "webb 0.5.7",
  "webb-relayer",
  "webb-relayer-config",
  "webb-relayer-store",
@@ -5950,7 +5967,7 @@ dependencies = [
  "url",
  "warp",
  "warp-real-ip",
- "webb",
+ "webb 0.5.10",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
@@ -5975,7 +5992,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.16",
  "url",
- "webb",
+ "webb 0.5.7",
  "webb-proposals",
  "webb-relayer-store",
  "webb-relayer-types",
@@ -5993,7 +6010,7 @@ dependencies = [
  "sled",
  "tempfile",
  "tracing",
- "webb",
+ "webb 0.5.7",
  "webb-proposals",
  "webb-relayer-utils",
 ]
@@ -6009,7 +6026,7 @@ dependencies = [
  "tiny-keccak",
  "tracing",
  "url",
- "webb",
+ "webb 0.5.7",
 ]
 
 [[package]]
@@ -6026,7 +6043,7 @@ dependencies = [
  "thiserror",
  "url",
  "warp",
- "webb",
+ "webb 0.5.7",
  "webb-proposals",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { version = "^1", default-features = false }
 paw = { version = "^1.0", optional = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 hex = { version = "0.4", default-features = false }
-webb = { version = "0.5.7", default-features = false }
+webb = {path = "/Users/salman01zz/Webb-Tools/webb-rs/", version = "0.5.10", default-features = false }
 webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
 ethereum-types = "0.13.1"
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = { version = "^1", default-features = false }
 paw = { version = "^1.0", optional = true }
 rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 hex = { version = "0.4", default-features = false }
-webb = {path = "/Users/salman01zz/Webb-Tools/webb-rs/", version = "0.5.10", default-features = false }
+webb = { version = "0.5.10", default-features = false }
 webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
 ethereum-types = "0.13.1"
 dotenv = "0.15.0"

--- a/crates/relayer-store/src/mem.rs
+++ b/crates/relayer-store/src/mem.rs
@@ -28,9 +28,9 @@ type MemStoreForVec = HashMap<HistoryStoreKey, Vec<(u32, Vec<u8>)>>;
 /// InMemoryStore is a store that stores the history of events in memory.
 #[derive(Clone, Default)]
 pub struct InMemoryStore {
-    store: Arc<RwLock<MemStore>>,
+    _store: Arc<RwLock<MemStore>>,
     store_for_vec: Arc<RwLock<MemStoreForVec>>,
-    last_block_numbers: Arc<RwLock<HashMap<HistoryStoreKey, types::U64>>>,
+    last_block_numbers: Arc<RwLock<HashMap<HistoryStoreKey, u64>>>,
 }
 
 impl std::fmt::Debug for InMemoryStore {
@@ -44,8 +44,8 @@ impl HistoryStore for InMemoryStore {
     fn get_last_block_number<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
-        default_block_number: types::U64,
-    ) -> crate::Result<types::U64> {
+        default_block_number: u64,
+    ) -> crate::Result<u64> {
         let guard = self.last_block_numbers.read();
         let val = guard
             .get(&key.into())
@@ -58,8 +58,8 @@ impl HistoryStore for InMemoryStore {
     fn set_last_block_number<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
-        block_number: types::U64,
-    ) -> crate::Result<types::U64> {
+        block_number: u64,
+    ) -> crate::Result<u64> {
         let mut guard = self.last_block_numbers.write();
         let val = guard.entry(key.into()).or_insert(block_number);
         let old = *val;
@@ -69,14 +69,14 @@ impl HistoryStore for InMemoryStore {
 }
 
 impl LeafCacheStore for InMemoryStore {
-    type Output = Vec<types::H256>;
+    type Output = Vec<Vec<u8>>;
 
     #[tracing::instrument(skip(self))]
     fn get_leaves<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
     ) -> crate::Result<Self::Output> {
-        let guard = self.store.read();
+        let guard = self.store_for_vec.read();
         let val = guard
             .get(&key.into())
             .cloned()
@@ -91,9 +91,9 @@ impl LeafCacheStore for InMemoryStore {
     fn insert_leaves<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
-        leaves: &[(u32, types::H256)],
+        leaves: &[(u32, Vec<u8>)],
     ) -> crate::Result<()> {
-        let mut guard = self.store.write();
+        let mut guard = self.store_for_vec.write();
         guard
             .entry(key.into())
             .and_modify(|v| v.extend_from_slice(leaves))
@@ -105,17 +105,17 @@ impl LeafCacheStore for InMemoryStore {
     fn get_last_deposit_block_number<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
-    ) -> crate::Result<types::U64> {
-        Ok(types::U64::from(0))
+    ) -> crate::Result<u64> {
+        Ok(0u64)
     }
 
     #[tracing::instrument(skip(self))]
     fn insert_last_deposit_block_number<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
-        block_number: types::U64,
-    ) -> crate::Result<types::U64> {
-        Ok(types::U64::from(0))
+        block_number: u64,
+    ) -> crate::Result<u64> {
+        Ok(0u64)
     }
 }
 
@@ -158,8 +158,8 @@ impl EncryptedOutputCacheStore for InMemoryStore {
     >(
         &self,
         key: K,
-    ) -> crate::Result<types::U64> {
-        Ok(types::U64::from(0))
+    ) -> crate::Result<u64> {
+        Ok(0u64)
     }
 
     #[tracing::instrument(skip(self))]
@@ -168,8 +168,8 @@ impl EncryptedOutputCacheStore for InMemoryStore {
     >(
         &self,
         key: K,
-        block_number: types::U64,
-    ) -> crate::Result<types::U64> {
-        Ok(types::U64::from(0))
+        block_number: u64,
+    ) -> crate::Result<u64> {
+        Ok(0u64)
     }
 }

--- a/services/block-poller/src/block_poller.rs
+++ b/services/block-poller/src/block_poller.rs
@@ -1,4 +1,3 @@
-use ethereum_types::U64;
 use futures::prelude::*;
 use std::cmp;
 use std::sync::Arc;
@@ -105,13 +104,14 @@ pub trait BlockPoller {
                 .get_chainid()
                 .map_err(Into::into)
                 .map_err(backoff::Error::transient)
-                .await?;
+                .await?
+                .as_u32();
             tracing::info!("chain id: {}", chain_id);
             // now we start polling for new events.
             loop {
                 let block = store.get_last_block_number(
                     chain_id,
-                    U64::from(listener_config.start_block.unwrap_or_default()),
+                    listener_config.start_block.unwrap_or_default(),
                 )?;
                 tracing::trace!(
                     "last block number: {}",
@@ -127,13 +127,13 @@ pub trait BlockPoller {
                     .await;
 
                 let current_block_number = match current_block_number_result {
-                    Ok(block_number) => block_number,
+                    Ok(block_number) => block_number.as_u64(),
                     Err(e) => {
                         tracing::error!(
                             "Error {:?} while getting block number",
                             e
                         );
-                        U64::zero()
+                        0u64
                     }
                 };
 

--- a/src/events_watcher/evm/signature_bridge_watcher.rs
+++ b/src/events_watcher/evm/signature_bridge_watcher.rs
@@ -129,7 +129,7 @@ impl EventHandler for SignatureBridgeGovernanceOwnershipTransferredHandler {
                 // do this transfer.
                 let chain_id = wrapper.contract.get_chain_id().call().await?;
                 let tx_key = SledQueueKey::from_evm_with_custom_key(
-                    chain_id,
+                    chain_id.as_u32(),
                     make_transfer_ownership_key(v.new_owner.to_fixed_bytes())
                 );
                 let exist_tx = QueueStore::<TypedTransaction>::has_item(&store, tx_key)?;
@@ -209,7 +209,7 @@ where
         let chain_id = contract.get_chain_id().call().await?;
         let proposal_data_hash = utils::keccak256(&proposal_data);
         let tx_key = SledQueueKey::from_evm_with_custom_key(
-            chain_id,
+            chain_id.as_u32(),
             make_execute_proposal_key(proposal_data_hash),
         );
 
@@ -289,7 +289,7 @@ where
         let new_governor_address =
             eth_address_from_uncompressed_public_key(&public_key);
         let tx_key = SledQueueKey::from_evm_with_custom_key(
-            chain_id,
+            chain_id.as_u32(),
             make_transfer_ownership_key(new_governor_address.to_fixed_bytes()),
         );
 

--- a/src/events_watcher/substrate/mod.rs
+++ b/src/events_watcher/substrate/mod.rs
@@ -24,3 +24,5 @@ pub use signature_bridge_watcher::*;
 pub use vanchor_leaves_watcher::*;
 #[doc(hidden)]
 pub use vanchor_watcher::*;
+#[doc(hidden)]
+pub use vanchor_encrypted_output_watcher::*;

--- a/src/events_watcher/substrate/mod.rs
+++ b/src/events_watcher/substrate/mod.rs
@@ -21,8 +21,8 @@ use super::{BlockNumberOf, SubstrateEventWatcher};
 #[doc(hidden)]
 pub use signature_bridge_watcher::*;
 #[doc(hidden)]
+pub use vanchor_encrypted_output_watcher::*;
+#[doc(hidden)]
 pub use vanchor_leaves_watcher::*;
 #[doc(hidden)]
 pub use vanchor_watcher::*;
-#[doc(hidden)]
-pub use vanchor_encrypted_output_watcher::*;

--- a/src/events_watcher/substrate/signature_bridge_watcher.rs
+++ b/src/events_watcher/substrate/signature_bridge_watcher.rs
@@ -22,7 +22,6 @@ use super::{BlockNumberOf, SubstrateEventWatcher};
 use crate::events_watcher::SubstrateBridgeWatcher;
 use webb_relayer_store::sled::{SledQueueKey,SledStore};
 use webb_relayer_store::{BridgeCommand, QueueStore};
-use ethereum_types::U256;
 use webb::substrate::{
     protocol_substrate_runtime,
 };
@@ -87,7 +86,7 @@ impl SubstrateBridgeWatcher for SubstrateBridgeEventWatcher {
     #[tracing::instrument(skip_all)]
     async fn handle_cmd(
         &self,
-        chain_id: U256,
+        chain_id: u32,
         store: Arc<Self::Store>,
         api: Arc<Self::Client>,
         cmd: BridgeCommand,
@@ -129,7 +128,7 @@ where
     #[tracing::instrument(skip_all)]
     async fn execute_proposal_with_signature(
         &self,
-        chain_id: U256,
+        chain_id: u32,
         store: Arc<<Self as SubstrateEventWatcher>::Store>,
         api: Arc<<Self as SubstrateEventWatcher>::Client>,
         (proposal_data, signature): (Vec<u8>, Vec<u8>),
@@ -190,8 +189,7 @@ where
             parse_call_from_proposal_data(&proposal_data);
         let _proposal_encoded_call: Call =
             scale::Decode::decode(&mut parsed_proposal_bytes.as_slice())?;
-        let typed_chain_id =
-            webb_proposals::TypedChainId::Substrate(chain_id.as_u32());
+        let typed_chain_id = webb_proposals::TypedChainId::Substrate(chain_id);
 
         // Enqueue transaction call data in protocol-substrate transaction queue
         let execute_proposal_call = ExecuteProposal {
@@ -231,7 +229,7 @@ where
     #[tracing::instrument(skip_all)]
     async fn transfer_ownership_with_signature(
         &self,
-        chain_id: U256,
+        chain_id: u32,
         store: Arc<<Self as SubstrateEventWatcher>::Store>,
         api: Arc<<Self as SubstrateEventWatcher>::Client>,
         (public_key, nonce, signature): (Vec<u8>, u32, Vec<u8>),
@@ -283,7 +281,7 @@ where
             tracing::Level::DEBUG,
             kind = %crate::probe::Kind::SignatureBridge,
             call = "transfer_ownership_with_signature_pub_key",
-            chain_id = %chain_id.as_u64(),
+            chain_id = %chain_id,
             new_maintainer = %hex::encode(&new_maintainer),
             %nonce,
             signature = %hex::encode(&signature),

--- a/src/events_watcher/substrate/vanchor_encrypted_output_watcher.rs
+++ b/src/events_watcher/substrate/vanchor_encrypted_output_watcher.rs
@@ -1,1 +1,100 @@
+// Copyright 2022 Webb Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+use super::{BlockNumberOf, SubstrateEventWatcher};
+use crate::metric;
+use std::sync::Arc;
+use webb::evm::ethers::types;
+use webb::substrate::protocol_substrate_runtime;
+use webb::substrate::protocol_substrate_runtime::api as RuntimeApi;
+use webb::substrate::protocol_substrate_runtime::api::v_anchor_bn254;
+use webb::substrate::subxt::{self, OnlineClient};
+use webb_relayer_store::sled::SledStore;
+use webb_relayer_store::EncryptedOutputCacheStore;
+// An Substrate VAnchor Leaves Watcher that watches for Deposit events and save the leaves to the store.
+/// It serves as a cache for leaves that could be used by dApp for proof generation.
+#[derive(Clone, Debug, Default)]
+pub struct SubstrateVAnchorEncryptedOutputHandler;
 
+#[async_trait::async_trait]
+impl SubstrateEventWatcher for SubstrateVAnchorEncryptedOutputHandler {
+    const TAG: &'static str = "Substrate V-Anchor leaves watcher";
+
+    type RuntimeConfig = subxt::SubstrateConfig;
+
+    type Client = OnlineClient<Self::RuntimeConfig>;
+
+    type Event = protocol_substrate_runtime::api::Event;
+
+    type FilteredEvent = v_anchor_bn254::events::Transaction;
+
+    type Store = SledStore;
+
+    async fn handle_event(
+        &self,
+        store: Arc<Self::Store>,
+        api: Arc<Self::Client>,
+        (event, block_number): (Self::FilteredEvent, BlockNumberOf<Self>),
+        _metrics: Arc<metric::Metrics>,
+    ) -> crate::Result<()> {
+        let at_hash_addr = RuntimeApi::storage()
+            .system()
+            .block_hash(block_number as u64);
+        let at_hash = api.storage().fetch(&at_hash_addr, None).await?.unwrap();
+
+        // fetch leaf_index from merkle tree at given block_number
+        let next_leaf_index_addr = RuntimeApi::storage()
+            .merkle_tree_bn254()
+            .next_leaf_index(event.tree_id);
+        let next_leaf_index = api
+            .storage()
+            .fetch(&next_leaf_index_addr, Some(at_hash))
+            .await?
+            .unwrap();
+
+        // fetch chain_id
+        let chain_id_addr = RuntimeApi::constants()
+            .linkable_tree_bn254()
+            .chain_identifier();
+        let chain_id = api.constants().at(&chain_id_addr)?;
+        let chain_id = types::U256::from(chain_id);
+
+        let tree_id = event.tree_id.to_string();
+        let leaf_count = event.leafs.len();
+       
+        let mut index = next_leaf_index.saturating_sub(leaf_count as u32);
+        let mut output_store = Vec::with_capacity(leaf_count);
+        for encrypted_output in [event.encrypted_output1, event.encrypted_output2]{
+            let value = (index, encrypted_output.clone());
+            store.insert_encrypted_output((chain_id, tree_id.clone()), &[value])?;
+            store.insert_last_deposit_block_number_for_encrypted_output(
+                (chain_id, tree_id.clone()),
+                types::U64::from(block_number),
+            )?;
+            index += 1;
+            output_store.push(encrypted_output);
+        }
+        tracing::event!(
+            target: crate::probe::TARGET,
+            tracing::Level::DEBUG,
+            kind = %crate::probe::Kind::EncryptedOutputStore,
+            chain_id = %chain_id,
+            index = index,
+            encrypted_outputs = %format!("{:?}",output_store),
+            tree_id = %tree_id,
+            block_number = %block_number
+        );
+        Ok(())
+    }
+}

--- a/src/events_watcher/substrate/vanchor_encrypted_output_watcher.rs
+++ b/src/events_watcher/substrate/vanchor_encrypted_output_watcher.rs
@@ -29,7 +29,7 @@ pub struct SubstrateVAnchorEncryptedOutputHandler;
 
 #[async_trait::async_trait]
 impl SubstrateEventWatcher for SubstrateVAnchorEncryptedOutputHandler {
-    const TAG: &'static str = "Substrate V-Anchor leaves watcher";
+    const TAG: &'static str = "Substrate V-Anchor encrypted output handler";
 
     type RuntimeConfig = subxt::SubstrateConfig;
 
@@ -72,12 +72,17 @@ impl SubstrateEventWatcher for SubstrateVAnchorEncryptedOutputHandler {
 
         let tree_id = event.tree_id.to_string();
         let leaf_count = event.leafs.len();
-       
+
         let mut index = next_leaf_index.saturating_sub(leaf_count as u32);
         let mut output_store = Vec::with_capacity(leaf_count);
-        for encrypted_output in [event.encrypted_output1, event.encrypted_output2]{
+        for encrypted_output in
+            [event.encrypted_output1, event.encrypted_output2]
+        {
             let value = (index, encrypted_output.clone());
-            store.insert_encrypted_output((chain_id, tree_id.clone()), &[value])?;
+            store.insert_encrypted_output(
+                (chain_id, tree_id.clone()),
+                &[value],
+            )?;
             store.insert_last_deposit_block_number_for_encrypted_output(
                 (chain_id, tree_id.clone()),
                 types::U64::from(block_number),

--- a/src/events_watcher/substrate/vanchor_encrypted_output_watcher.rs
+++ b/src/events_watcher/substrate/vanchor_encrypted_output_watcher.rs
@@ -22,8 +22,8 @@ use webb::substrate::protocol_substrate_runtime::api::v_anchor_bn254;
 use webb::substrate::subxt::{self, OnlineClient};
 use webb_relayer_store::sled::SledStore;
 use webb_relayer_store::EncryptedOutputCacheStore;
-// An Substrate VAnchor Leaves Watcher that watches for Deposit events and save the leaves to the store.
-/// It serves as a cache for leaves that could be used by dApp for proof generation.
+// An Substrate VAnchor encrypted output Watcher that watches for Deposit events and save the encrypted output to the store.
+/// It serves as a cache for encrypted outputs that could be used by dApp.
 #[derive(Clone, Debug, Default)]
 pub struct SubstrateVAnchorEncryptedOutputHandler;
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,7 +20,13 @@ use std::error::Error;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
-use ethereum_types::{Address, H160, H256, U256, U64};
+use crate::context::RelayerContext;
+use crate::metric::Metrics;
+use crate::tx_relay::evm::vanchor::handle_vanchor_relay_tx;
+use crate::tx_relay::substrate::mixer::handle_substrate_mixer_relay_tx;
+use crate::tx_relay::substrate::vanchor::handle_substrate_vanchor_relay_tx;
+use crate::tx_relay::{MixerRelayTransaction, VAnchorRelayTransaction};
+use ethereum_types::{Address, H256, U256};
 use futures::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio::sync::mpsc;
@@ -35,13 +41,9 @@ use webb::evm::ethers::{
     types::Bytes,
 };
 use webb::substrate::subxt::ext::{sp_core::Pair, sp_runtime::AccountId32};
-
-use crate::context::RelayerContext;
-use crate::metric::Metrics;
-use crate::tx_relay::evm::vanchor::handle_vanchor_relay_tx;
-use crate::tx_relay::substrate::mixer::handle_substrate_mixer_relay_tx;
-use crate::tx_relay::substrate::vanchor::handle_substrate_vanchor_relay_tx;
-use crate::tx_relay::{MixerRelayTransaction, VAnchorRelayTransaction};
+use webb_proposals::{
+    ResourceId, SubstrateTargetSystem, TargetSystem, TypedChainId,
+};
 use webb_relayer_store::{EncryptedOutputCacheStore, LeafCacheStore};
 
 /// A wrapper type around [`I256`] that implements a correct way for [`Serialize`] and [`Deserialize`].
@@ -270,12 +272,12 @@ pub async fn handle_relayer_info(
 /// # Arguments
 ///
 /// * `store` - [Sled](https://sled.rs)-based database store
-/// * `chain_id` - An U256 representing the chain id of the chain to query
+/// * `chain_id` - An u32 representing the chain id of the chain to query
 /// * `contract` - An address of the contract to query
 /// * `ctx` - RelayContext reference that holds the configuration
 pub async fn handle_leaves_cache_evm(
     store: Arc<webb_relayer_store::sled::SledStore>,
-    chain_id: U256,
+    chain_id: u32,
     contract: Address,
     ctx: Arc<RelayerContext>,
 ) -> Result<impl warp::Reply, Infallible> {
@@ -284,8 +286,8 @@ pub async fn handle_leaves_cache_evm(
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     struct LeavesCacheResponse {
-        leaves: Vec<H256>,
-        last_queried_block: U64,
+        leaves: Vec<Vec<u8>>,
+        last_queried_block: u64,
     }
     // Unsupported feature response
     #[derive(Debug, Serialize)]
@@ -364,9 +366,15 @@ pub async fn handle_leaves_cache_evm(
             warp::http::StatusCode::FORBIDDEN,
         ));
     }
-    let leaves = store.get_leaves((chain_id, contract)).unwrap();
+    // create history store key
+    let src_target_system =
+        TargetSystem::new_contract_address(contract.to_fixed_bytes());
+    let src_typed_chain_id = TypedChainId::Evm(chain_id);
+    let history_store_key =
+        ResourceId::new(src_target_system, src_typed_chain_id);
+    let leaves = store.get_leaves(history_store_key).unwrap();
     let last_queried_block = store
-        .get_last_deposit_block_number((chain_id, contract))
+        .get_last_deposit_block_number(history_store_key)
         .unwrap();
 
     Ok(warp::reply::with_status(
@@ -384,13 +392,15 @@ pub async fn handle_leaves_cache_evm(
 /// # Arguments
 ///
 /// * `store` - [Sled](https://sled.rs)-based database store
-/// * `chain_id` - An U256 representing the chain id of the chain to query
-/// * `contract` - An address of the contract to query
+/// * `chain_id` - An u32 representing the chain id of the chain to query
+/// * `tree_id` - Tree id of the the source system to query
+/// * `pallet_id` - Pallet id of the the source system to query
 /// * `ctx` - RelayContext reference that holds the configuration
 pub async fn handle_leaves_cache_substrate(
     store: Arc<webb_relayer_store::sled::SledStore>,
-    chain_id: U256,
+    chain_id: u32,
     tree_id: u32,
+    pallet_id: u8,
     ctx: Arc<RelayerContext>,
 ) -> Result<impl warp::Reply, Infallible> {
     let config = ctx.config.clone();
@@ -398,8 +408,8 @@ pub async fn handle_leaves_cache_substrate(
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     struct LeavesCacheResponse {
-        leaves: Vec<H256>,
-        last_queried_block: U64,
+        leaves: Vec<Vec<u8>>,
+        last_queried_block: u64,
     }
     // Unsupported feature response
     #[derive(Debug, Serialize)]
@@ -418,15 +428,19 @@ pub async fn handle_leaves_cache_substrate(
         ));
     }
 
-    // storage key for substrate is of type (chain_id, address),where address is 20 bytes H160.
-    //since substrate pallet does not have contract address we use treeId instead.
-    let mut address_bytes = vec![];
-    address_bytes.extend_from_slice(tree_id.to_string().as_bytes());
-    address_bytes.resize(20, 0);
-    let address = H160::from_slice(&address_bytes);
-    let leaves = store.get_leaves((chain_id, address)).unwrap();
+    // create history store key
+    let src_typed_chain_id = TypedChainId::Substrate(chain_id);
+    let target = SubstrateTargetSystem::builder()
+        .pallet_index(pallet_id)
+        .tree_id(tree_id)
+        .build();
+    let src_target_system = TargetSystem::Substrate(target);
+    let history_store_key =
+        ResourceId::new(src_target_system, src_typed_chain_id);
+
+    let leaves = store.get_leaves(history_store_key).unwrap();
     let last_queried_block = store
-        .get_last_deposit_block_number((chain_id, address))
+        .get_last_deposit_block_number(history_store_key)
         .unwrap();
 
     Ok(warp::reply::with_status(
@@ -449,7 +463,7 @@ pub async fn handle_leaves_cache_substrate(
 /// * `ctx` - RelayContext reference that holds the configuration
 pub async fn handle_leaves_cache_cosmwasm(
     store: Arc<webb_relayer_store::sled::SledStore>,
-    chain_id: U256,
+    chain_id: u32,
     contract: String,
     ctx: Arc<RelayerContext>,
 ) -> Result<impl warp::Reply, Infallible> {
@@ -458,8 +472,8 @@ pub async fn handle_leaves_cache_cosmwasm(
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     struct LeavesCacheResponse {
-        leaves: Vec<H256>,
-        last_queried_block: U64,
+        leaves: Vec<Vec<u8>>,
+        last_queried_block: u64,
     }
     // Unsupported feature response
     #[derive(Debug, Serialize)]
@@ -541,10 +555,9 @@ pub async fn handle_leaves_cache_cosmwasm(
             warp::http::StatusCode::FORBIDDEN,
         ));
     }
-    let leaves = store.get_leaves((chain_id, contract.to_string())).unwrap();
-    let last_queried_block = store
-        .get_last_deposit_block_number((chain_id, contract))
-        .unwrap();
+    let leaves = store.get_leaves(chain_id).unwrap();
+    let last_queried_block =
+        store.get_last_deposit_block_number(chain_id).unwrap();
 
     Ok(warp::reply::with_status(
         warp::reply::json(&LeavesCacheResponse {
@@ -567,7 +580,7 @@ pub async fn handle_leaves_cache_cosmwasm(
 /// * `ctx` - RelayContext reference that holds the configuration
 pub async fn handle_encrypted_outputs_cache_evm(
     store: Arc<webb_relayer_store::sled::SledStore>,
-    chain_id: U256,
+    chain_id: u32,
     contract: Address,
     ctx: Arc<RelayerContext>,
 ) -> Result<impl warp::Reply, Infallible> {
@@ -577,7 +590,7 @@ pub async fn handle_encrypted_outputs_cache_evm(
     #[serde(rename_all = "camelCase")]
     struct EncryptedOutputsCacheResponse {
         encrypted_outputs: Vec<Vec<u8>>,
-        last_queried_block: U64,
+        last_queried_block: u64,
     }
     // Unsupported feature response
     #[derive(Debug, Serialize)]
@@ -656,12 +669,16 @@ pub async fn handle_encrypted_outputs_cache_evm(
             warp::http::StatusCode::FORBIDDEN,
         ));
     }
+    // create history store key
+    let src_target_system =
+        TargetSystem::new_contract_address(contract.to_fixed_bytes());
+    let src_typed_chain_id = TypedChainId::Evm(chain_id);
+    let history_store_key =
+        ResourceId::new(src_target_system, src_typed_chain_id);
     let encrypted_output =
-        store.get_encrypted_output((chain_id, contract)).unwrap();
+        store.get_encrypted_output(history_store_key).unwrap();
     let last_queried_block = store
-        .get_last_deposit_block_number_for_encrypted_output((
-            chain_id, contract,
-        ))
+        .get_last_deposit_block_number_for_encrypted_output(history_store_key)
         .unwrap();
 
     Ok(warp::reply::with_status(

--- a/src/tx_queue/evm/evm_tx_queue.rs
+++ b/src/tx_queue/evm/evm_tx_queue.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ethereum_types::H256;
+use ethereum_types::{H256, U64};
 use futures::TryFutureExt;
 use rand::Rng;
 use webb::evm::ethers::core::types::transaction::eip2718::TypedTransaction;
@@ -101,7 +101,9 @@ where
             .map_err(|_| {
                 crate::Error::Generic("Failed to fetch chain id from client")
             })
-            .await?;
+            .await?
+            .as_u32();
+
         let store = self.store;
         let backoff = backoff::ExponentialBackoff {
             max_elapsed_time: None,
@@ -112,7 +114,7 @@ where
             tracing::Level::DEBUG,
             kind = %crate::probe::Kind::TxQueue,
             ty = "EVM",
-            chain_id = %chain_id.as_u64(),
+            chain_id = %chain_id,
             starting = true,
         );
 
@@ -132,7 +134,8 @@ where
                 let maybe_explorer = &chain_config.explorer;
                 let mut tx_hash: H256;
                 if let Some(mut raw_tx) = maybe_tx {
-                    let raw_tx = raw_tx.set_chain_id(chain_id.as_u64()).clone();
+                    let raw_tx =
+                        raw_tx.set_chain_id(U64::from(chain_id)).clone();
                     let my_tx_hash = raw_tx.sighash();
                     tx_hash = my_tx_hash;
                     // dry run test
@@ -145,7 +148,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "EVM",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 dry_run = "passed",
                                 %tx_hash,
                             );
@@ -156,7 +159,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "EVM",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 errored = true,
                                 error = %err,
                                 dry_run = "failed",
@@ -175,7 +178,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "EVM",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 pending = true,
                                 %tx_hash,
                             );
@@ -224,7 +227,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "EVM",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 errored = true,
                                 %tx_hash,
                                 error = %e,
@@ -261,7 +264,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "EVM",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 finalized = true,
                                 %tx_hash,
                             );
@@ -310,7 +313,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "EVM",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 errored = true,
                                 %tx_hash,
                                 error = %e,

--- a/src/tx_queue/substrate/substrate_tx_queue.rs
+++ b/src/tx_queue/substrate/substrate_tx_queue.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 use crate::context::RelayerContext;
-use ethereum_types::U256;
 use futures::StreamExt;
 use futures::TryFutureExt;
 use rand::Rng;
@@ -44,7 +43,7 @@ where
     S: QueueStore<WebbDynamicTxPayload<'a>, Key = SledQueueKey>,
 {
     ctx: RelayerContext,
-    chain_id: U256,
+    chain_id: u32,
     store: Arc<S>,
     _marker: PhantomData<&'a ()>,
 }
@@ -69,7 +68,7 @@ where
     /// let tx_queue = SubstrateTxQueue::new(ctx, chain_name.clone(), store);
     /// ```
 
-    pub fn new(ctx: RelayerContext, chain_id: U256, store: Arc<S>) -> Self {
+    pub fn new(ctx: RelayerContext, chain_id: u32, store: Arc<S>) -> Self {
         Self {
             ctx,
             chain_id,
@@ -136,7 +135,7 @@ where
             tracing::Level::DEBUG,
             kind = %crate::probe::Kind::TxQueue,
             ty = "SUBSTRATE",
-            chain_id = %chain_id.as_u64(),
+            chain_id = %chain_id,
             starting = true,
         );
 
@@ -173,7 +172,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "SUBSTRATE",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 dry_run = "passed"
                             );
                         }
@@ -183,7 +182,7 @@ where
                                 tracing::Level::DEBUG,
                                 kind = %crate::probe::Kind::TxQueue,
                                 ty = "SUBSTRATE",
-                                chain_id = %chain_id.as_u64(),
+                                chain_id = %chain_id,
                                 errored = true,
                                 error = %err,
                                 dry_run = "failed"
@@ -211,7 +210,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     errored = true,
                                     error = %err,
                                 );
@@ -226,7 +225,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Future",
                                 );
                             }
@@ -236,7 +235,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Ready",
                                 );
                             }
@@ -246,7 +245,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Broadcast",
                                 );
                             }
@@ -256,7 +255,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "InBlock",
                                 );
                             }
@@ -266,7 +265,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Retracted",
                                 );
                             }
@@ -276,7 +275,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "FinalityTimeout",
                                 );
                             }
@@ -286,7 +285,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Finalized",
                                     finalized = true,
                                 );
@@ -303,7 +302,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Usurped",
                                 );
                             }
@@ -313,7 +312,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Dropped",
                                 );
                             }
@@ -323,7 +322,7 @@ where
                                     tracing::Level::DEBUG,
                                     kind = %crate::probe::Kind::TxQueue,
                                     ty = "SUBSTRATE",
-                                    chain_id = %chain_id.as_u64(),
+                                    chain_id = %chain_id,
                                     status = "Invalid",
                                 );
                             }

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -98,9 +98,7 @@ export class WebbRelayer {
   // data querying api for evm
   public async getLeavesEvm(chainId: string, contractAddress: string) {
     const endpoint = `http://127.0.0.1:${this.opts.port}/api/v1/leaves/evm/${chainId}/${contractAddress}`;
-    console.log(endpoint);
     const response = await fetch(endpoint);
-    console.log(response);
     return response;
   }
   // data querying api for substrate
@@ -111,7 +109,6 @@ export class WebbRelayer {
   ) {
     const endpoint = `http://127.0.0.1:${this.opts.port}/api/v1/leaves/substrate/${chainId}/${treeId}/${palletId}`;
     const response = await fetch(endpoint);
-    console.log(endpoint);
     return response;
   }
   public async getEncryptedOutputsEvm(

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -98,13 +98,20 @@ export class WebbRelayer {
   // data querying api for evm
   public async getLeavesEvm(chainId: string, contractAddress: string) {
     const endpoint = `http://127.0.0.1:${this.opts.port}/api/v1/leaves/evm/${chainId}/${contractAddress}`;
+    console.log(endpoint);
     const response = await fetch(endpoint);
+    console.log(response);
     return response;
   }
   // data querying api for substrate
-  public async getLeavesSubstrate(chainId: string, treeId: string) {
-    const endpoint = `http://127.0.0.1:${this.opts.port}/api/v1/leaves/substrate/${chainId}/${treeId}`;
+  public async getLeavesSubstrate(
+    chainId: string,
+    treeId: string,
+    palletId: string
+  ) {
+    const endpoint = `http://127.0.0.1:${this.opts.port}/api/v1/leaves/substrate/${chainId}/${treeId}/${palletId}`;
     const response = await fetch(endpoint);
+    console.log(endpoint);
     return response;
   }
   public async getEncryptedOutputsEvm(

--- a/tests/test/evm/evmToSubstrateTransaction.test.ts
+++ b/tests/test/evm/evmToSubstrateTransaction.test.ts
@@ -196,7 +196,7 @@ describe('Cross chain transaction <<>> Mocked Backend', function () {
       linkedAnchors: [
         { type: 'Raw', resourceId: substrateResourceId.toString() },
       ],
-      blockConfirmations: 15
+      blockConfirmations: 15,
     });
 
     // This are pre-requisites for creating substrate chain.

--- a/tests/test/evm/vanchorPrivateTransaction.test.ts
+++ b/tests/test/evm/vanchorPrivateTransaction.test.ts
@@ -546,7 +546,7 @@ describe('Vanchor Private Tx relaying with mocked governor', function () {
     this.retries(0);
     const vanchor1 = signatureVBridge.getVAnchor(localChain1.chainId)!;
     // It should fail since data querying is not configured for relayer
-    const chainId = localChain1.underlyingChainId.toString(16);
+    const chainId = localChain1.underlyingChainId.toString();
     const response = await webbRelayer.getLeavesEvm(
       chainId,
       vanchor1.contract.address
@@ -559,7 +559,7 @@ describe('Vanchor Private Tx relaying with mocked governor', function () {
     this.retries(0);
     const vanchor1 = signatureVBridge.getVAnchor(localChain1.chainId)!;
     // It should fail since data querying is not configured for relayer
-    const chainId = localChain1.underlyingChainId.toString(16);
+    const chainId = localChain1.underlyingChainId.toString();
     const response = await webbRelayer.getEncryptedOutputsEvm(
       chainId,
       vanchor1.contract.address

--- a/tests/test/evm/vanchorTransactionRelayer.test.ts
+++ b/tests/test/evm/vanchorTransactionRelayer.test.ts
@@ -239,7 +239,7 @@ describe('Vanchor Transaction relayer', function () {
 
     // now we call relayer leaf API to check no of leaves stored in LeafStorageCache
     // are equal to no of deposits made. Each VAnchor deposit generates 2 leaf entries
-    const chainId = localChain1.underlyingChainId.toString(16);
+    const chainId = localChain1.underlyingChainId.toString();
     const response = await webbRelayer.getLeavesEvm(
       chainId,
       vanchor1.contract.address
@@ -315,7 +315,7 @@ describe('Vanchor Transaction relayer', function () {
 
     // now we call relayer leaf API to check no of leaves stored in LeafStorageCache
     // are equal to no of deposits made. Each VAnchor deposit generates 2 leaf entries
-    const chainId = localChain1.underlyingChainId.toString(16);
+    const chainId = localChain1.underlyingChainId.toString();
 
     const response = await webbRelayer.getEncryptedOutputsEvm(
       chainId,

--- a/tests/test/signatureBridge.test.ts
+++ b/tests/test/signatureBridge.test.ts
@@ -478,7 +478,7 @@ describe('Signature Bridge <> Mocked Proposal Signing Backend', function () {
       port: relayerPort,
       tmp: true,
       configDir: tmpDirPath,
-      showLogs: true,
+      showLogs: false,
       verbosity: 3,
     });
     await webbRelayer.waitUntilReady();

--- a/tests/test/substrate/signatureBridgeVanchor.test.ts
+++ b/tests/test/substrate/signatureBridgeVanchor.test.ts
@@ -29,6 +29,7 @@ import {
   WebbRelayer,
   Pallet,
   RelayerMetricResponse,
+  EncryptedOutputsCacheResponse,
 } from '../../lib/webbRelayer.js';
 import { LocalProtocolSubstrate } from '../../lib/localProtocolSubstrate.js';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
@@ -63,7 +64,7 @@ import { makeSubstrateTargetSystem } from '../../lib/webbProposals.js';
 import { expect } from 'chai';
 const { ecdsaSign } = pkg;
 
-describe('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocked Backend', function () {
+describe.only('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocked Backend', function () {
   const tmpDirPath = temp.mkdirSync();
   let aliceNode: LocalProtocolSubstrate;
   let bobNode: LocalProtocolSubstrate;
@@ -145,12 +146,12 @@ describe('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocked Bac
       port: relayerPort,
       tmp: true,
       configDir: tmpDirPath,
-      showLogs: false,
+      showLogs: true,
     });
     await webbRelayer.waitUntilReady();
   });
 
-  it('Relayer should create and relay anchor update proposal to signature bridge for execution', async () => {
+  it.only('Relayer should create and relay anchor update proposal to signature bridge for execution', async () => {
     const api = await aliceNode.api();
     const account = createAccount('//Dave');
     //create vanchor
@@ -193,6 +194,24 @@ describe('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocked Bac
         chain_id: chainId.toString(),
         finalized: true,
       },
+    });
+
+    // fetch encrypted data
+    // chainId
+    let chainIdentifier = await aliceNode.getChainId();
+    const chainIdHex = chainIdentifier.toString(16);
+
+    const response = await webbRelayer.getEncryptedOutputsEvm(
+      chainIdHex,
+      treeId.toString()
+    );
+    expect(response.status).equal(200);
+
+    let store = response.json() as Promise<EncryptedOutputsCacheResponse>;
+    store.then((resp) => {
+      console.log("encrypted output resp");
+      console.log(resp);
+      expect(resp.encrypted_outputs.length).to.equal(2);
     });
 
     // check metrics gathered

--- a/tests/test/substrate/signatureBridgeVanchor.test.ts
+++ b/tests/test/substrate/signatureBridgeVanchor.test.ts
@@ -29,7 +29,6 @@ import {
   WebbRelayer,
   Pallet,
   RelayerMetricResponse,
-  EncryptedOutputsCacheResponse,
 } from '../../lib/webbRelayer.js';
 import { LocalProtocolSubstrate } from '../../lib/localProtocolSubstrate.js';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
@@ -64,7 +63,7 @@ import { makeSubstrateTargetSystem } from '../../lib/webbProposals.js';
 import { expect } from 'chai';
 const { ecdsaSign } = pkg;
 
-describe.only('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocked Backend', function () {
+describe('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocked Backend', function () {
   const tmpDirPath = temp.mkdirSync();
   let aliceNode: LocalProtocolSubstrate;
   let bobNode: LocalProtocolSubstrate;
@@ -146,12 +145,12 @@ describe.only('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocke
       port: relayerPort,
       tmp: true,
       configDir: tmpDirPath,
-      showLogs: true,
+      showLogs: false,
     });
     await webbRelayer.waitUntilReady();
   });
 
-  it.only('Relayer should create and relay anchor update proposal to signature bridge for execution', async () => {
+  it('Relayer should create and relay anchor update proposal to signature bridge for execution', async () => {
     const api = await aliceNode.api();
     const account = createAccount('//Dave');
     //create vanchor
@@ -194,24 +193,6 @@ describe.only('Substrate Signature Bridge Relaying On Vanchor Deposit <<>> Mocke
         chain_id: chainId.toString(),
         finalized: true,
       },
-    });
-
-    // fetch encrypted data
-    // chainId
-    let chainIdentifier = await aliceNode.getChainId();
-    const chainIdHex = chainIdentifier.toString(16);
-
-    const response = await webbRelayer.getEncryptedOutputsEvm(
-      chainIdHex,
-      treeId.toString()
-    );
-    expect(response.status).equal(200);
-
-    let store = response.json() as Promise<EncryptedOutputsCacheResponse>;
-    store.then((resp) => {
-      console.log("encrypted output resp");
-      console.log(resp);
-      expect(resp.encrypted_outputs.length).to.equal(2);
     });
 
     // check metrics gathered

--- a/tests/test/substrate/vanchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/vanchorTransactionRelayer.test.ts
@@ -254,11 +254,10 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
 
     // chainId
     let chainIdentifier = await aliceNode.getChainId();
-    const chainIdHex = chainIdentifier.toString(16);
     // now we call relayer leaf API to check no of leaves stored in LeafStorageCache
     // are equal to no of deposits made.
     const response = await webbRelayer.getLeavesSubstrate(
-      chainIdHex,
+      chainIdentifier.toString(),
       treeId.toString(),
       '44' // pallet Id
     );

--- a/tests/test/substrate/vanchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/vanchorTransactionRelayer.test.ts
@@ -100,6 +100,7 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
       suri: '//Charlie',
       chainId: chainId,
       proposalSigningBackend: { type: 'Mocked', privateKey: PK1 },
+      features: { governanceRelay: false, privateTxRelay: false },
     });
 
     // now start the relayer
@@ -258,7 +259,8 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
     // are equal to no of deposits made.
     const response = await webbRelayer.getLeavesSubstrate(
       chainIdHex,
-      treeId.toString()
+      treeId.toString(),
+      '44' // pallet Id
     );
     expect(response.status).equal(200);
     let leavesStore = response.json() as Promise<LeavesCacheResponse>;


### PR DESCRIPTION
## Summary of changes
- [x]  Encrypted output watcher for substrate
- [x]  Removed `ethereum-types` used in relayer storage and substrate watchers
- [x] Updated `HistoryStoreKey` to use ResourceId
## Note 
I have not initialized this watcher since we don't have a substrate event handler with which we can run multiple event handlers for one event watcher. We will initialize it once we have the substrate event handler 
refers to issue #286 
### Reference issue to close (if applicable)
- Closes #276 

-----
### Code Checklist 

- [ ] Tested
- [x] Documented
