### PR TITLE
chore: update actions and rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   install-cross:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - uses: XAMPPRocky/get-github-release@v1
@@ -39,13 +39,13 @@ jobs:
     runs-on: macos-latest
     needs: install-cross
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Setup DVC
         uses: iterative/setup-dvc@v1
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: [stable]
+        channel: [nightly-2022-05-15]
         target:
           - x86_64-apple-darwin
 
@@ -80,13 +80,13 @@ jobs:
     steps:
       - name: install system build dependencies
         run: sudo apt-get update && sudo apt-get install ${DEV_PACKAGES}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Setup DVC
         uses: iterative/setup-dvc@v1
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: [stable]
+        channel: [nightly-2022-05-15]
         target:
           - aarch64-unknown-linux-musl
           - x86_64-unknown-linux-musl

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,16 +20,16 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly-2022-05-15
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2
 
       - name: Run Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
@@ -37,4 +37,4 @@ jobs:
           args: '--avoid-cfg-tarpaulin --out Xml --locked --jobs 16 --timeout 3600 --skip-clean -- --test-threads 16 '
 
       - name: Upload CodeCov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly-2022-05-15
           override: false
           components: clippy
       - name: Create Clippy Lints on Github PRs
@@ -53,7 +53,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly-2022-05-15
           override: false
           components: rustfmt
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-05-15"
 components = ["rustfmt", "clippy"]
 targets = []


### PR DESCRIPTION
## Summary of changes
- Updates action versions 
- Updates rust toolchain to use `nightly-2022-05-15` which is what we are defaulting to on dkg-substrate 

### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
