### PR TITLE
chore: testing downgraded cargo tarpaulin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Run Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.22.0'
           args: '--avoid-cfg-tarpaulin --out Xml --locked --jobs 1 --timeout 3600 --skip-clean -- --test-threads 16 '
 
       - name: Upload CodeCov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.22.0'
+          version: '0.23.0'
           args: '--avoid-cfg-tarpaulin --out Xml --locked --jobs 1 --timeout 3600 --skip-clean -- --test-threads 16 '
 
       - name: Upload CodeCov


### PR DESCRIPTION
## Summary of changes
- Downgrading `cargo tarpaulin` from `v0.23.1` to `v0.22.0` due to parsing error. See posted issue [here](https://github.com/xd009642/tarpaulin/issues/1157) for more details.


### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
