### PR TITLE
Improved error handling and code cleanup in tx-relay crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ store/
 .cargo/
 .DS_Store
 .vscode/
+.idea/

--- a/crates/tx-relay/src/evm/mod.rs
+++ b/crates/tx-relay/src/evm/mod.rs
@@ -26,98 +26,52 @@ pub async fn handle_evm_tx<M, D>(
     chain_id: u64,
     metrics: Arc<Mutex<metric::Metrics>>,
     resource_id: ResourceId,
-) where
+) -> Result<(), CommandResponse>
+where
     M: Middleware,
     D: Detokenize,
 {
     use CommandResponse::*;
     // Make a dry call, to make sure the transaction will go through successfully
     // to avoid wasting fees on invalid calls.
-    match call.call().await {
-        Ok(_) => {
-            let _ = stream.send(Withdraw(WithdrawStatus::Valid)).await;
-            tracing::debug!("Proof is valid");
-        }
-        Err(e) => {
-            tracing::error!("Error Client sent an invalid proof: {}", e);
-            let err = into_withdraw_error(e);
-            let _ = stream.send(Withdraw(err)).await;
-            return;
-        }
-    };
+    call.call().await.map_err(|e| {
+        tracing::error!("Error Client sent an invalid proof: {}", e);
+        Withdraw(into_withdraw_error(e))
+    })?;
+    let _ = stream.send(Withdraw(WithdrawStatus::Valid)).await;
+    tracing::debug!("Proof is valid");
 
-    let tx = match call.send().await {
-        Ok(pending) => {
-            let _ = stream.send(Withdraw(WithdrawStatus::Sent)).await;
-            let tx_hash = *pending;
-            tracing::event!(
-                target: webb_relayer_utils::probe::TARGET,
-                tracing::Level::DEBUG,
-                kind = %webb_relayer_utils::probe::Kind::PrivateTx,
-                ty = "EVM",
-                chain_id = %chain_id,
-                pending = true,
-                %tx_hash,
-            );
-            let result = pending.interval(Duration::from_millis(1000)).await;
-            let _ = stream
-                .send(Withdraw(WithdrawStatus::Submitted { tx_hash }))
-                .await;
-            result
-        }
-        Err(e) => {
-            tracing::event!(
-                target: webb_relayer_utils::probe::TARGET,
-                tracing::Level::DEBUG,
-                kind = %webb_relayer_utils::probe::Kind::PrivateTx,
-                ty = "EVM",
-                chain_id = %chain_id,
-                errored = true,
-                error = %e
-            );
-            let err = into_withdraw_error(e);
-            let _ = stream.send(Withdraw(err)).await;
-            return;
-        }
-    };
-    match tx {
-        Ok(Some(receipt)) => {
-            tracing::event!(
-                target: webb_relayer_utils::probe::TARGET,
-                tracing::Level::DEBUG,
-                kind = %webb_relayer_utils::probe::Kind::PrivateTx,
-                ty = "EVM",
-                chain_id = %chain_id,
-                finalized = true,
-                tx_hash = %receipt.transaction_hash,
-            );
-            // gas spent by relayer on particular resource.
-            let gas_price = receipt.gas_used.unwrap_or_default();
-            let mut metrics = metrics.lock().await;
-            let resource_metric = metrics
-                .resource_metric_map
-                .entry(resource_id)
-                .or_insert_with(|| {
-                    Metrics::register_resource_id_counters(resource_id)
-                });
+    let pending = call.send().await.map_err(|e| {
+        tracing::event!(
+            target: webb_relayer_utils::probe::TARGET,
+            tracing::Level::DEBUG,
+            kind = %webb_relayer_utils::probe::Kind::PrivateTx,
+            ty = "EVM",
+            chain_id = %chain_id,
+            errored = true,
+            error = %e
+        );
+        Withdraw(into_withdraw_error(e))
+    })?;
 
-            resource_metric
-                .total_gas_spent
-                .inc_by(gas_price.as_u64() as f64);
-            drop(metrics);
-            let _ = stream
-                .send(Withdraw(WithdrawStatus::Finalized {
-                    tx_hash: receipt.transaction_hash,
-                }))
-                .await;
-        }
-        Ok(None) => {
-            tracing::warn!("Transaction Dropped from Mempool!!");
-            let _ = stream
-                .send(Withdraw(WithdrawStatus::DroppedFromMemPool))
-                .await;
-        }
-        Err(e) => {
+    let _ = stream.send(Withdraw(WithdrawStatus::Sent)).await;
+    let tx_hash = *pending;
+    tracing::event!(
+        target: webb_relayer_utils::probe::TARGET,
+        tracing::Level::DEBUG,
+        kind = %webb_relayer_utils::probe::Kind::PrivateTx,
+        ty = "EVM",
+        chain_id = %chain_id,
+        pending = true,
+        %tx_hash,
+    );
+    let _ = stream
+        .send(Withdraw(WithdrawStatus::Submitted { tx_hash }))
+        .await;
+    let receipt = pending
+        .interval(Duration::from_millis(1000))
+        .await
+        .map_err(|e| {
             let reason = e.to_string();
             tracing::event!(
                 target: webb_relayer_utils::probe::TARGET,
@@ -128,10 +82,35 @@ pub async fn handle_evm_tx<M, D>(
                 errored = true,
                 error = %reason
             );
+            Withdraw(WithdrawStatus::Errored { reason, code: 4 })
+        })?
+        .ok_or(Withdraw(WithdrawStatus::DroppedFromMemPool))?;
 
-            let _ = stream
-                .send(Withdraw(WithdrawStatus::Errored { reason, code: 4 }))
-                .await;
-        }
-    };
+    tracing::event!(
+        target: webb_relayer_utils::probe::TARGET,
+        tracing::Level::DEBUG,
+        kind = %webb_relayer_utils::probe::Kind::PrivateTx,
+        ty = "EVM",
+        chain_id = %chain_id,
+        finalized = true,
+        tx_hash = %receipt.transaction_hash,
+    );
+    // gas spent by relayer on particular resource.
+    let gas_price = receipt.gas_used.unwrap_or_default();
+    let mut metrics = metrics.lock().await;
+    let resource_metric = metrics
+        .resource_metric_map
+        .entry(resource_id)
+        .or_insert_with(|| Metrics::register_resource_id_counters(resource_id));
+
+    resource_metric
+        .total_gas_spent
+        .inc_by(gas_price.as_u64() as f64);
+    drop(metrics);
+    let _ = stream
+        .send(Withdraw(WithdrawStatus::Finalized {
+            tx_hash: receipt.transaction_hash,
+        }))
+        .await;
+    Ok(())
 }

--- a/crates/tx-relay/src/evm/vanchor.rs
+++ b/crates/tx-relay/src/evm/vanchor.rs
@@ -12,7 +12,8 @@ use webb::evm::{
 };
 use webb_proposals::{ResourceId, TargetSystem, TypedChainId};
 use webb_relayer_context::RelayerContext;
-use webb_relayer_handler_utils::{CommandStream, EvmCommand, NetworkStatus};
+use webb_relayer_handler_utils::EvmVanchorCommand;
+use webb_relayer_handler_utils::{CommandStream, NetworkStatus};
 use webb_relayer_utils::metric::Metrics;
 
 /// Handler for VAnchor commands
@@ -24,14 +25,10 @@ use webb_relayer_utils::metric::Metrics;
 /// * `stream` - The stream to write the response to
 pub async fn handle_vanchor_relay_tx<'a>(
     ctx: RelayerContext,
-    cmd: EvmCommand,
+    cmd: EvmVanchorCommand,
     stream: CommandStream,
 ) -> Result<(), CommandResponse> {
     use CommandResponse::*;
-    let cmd = match cmd {
-        EvmCommand::VAnchor(cmd) => cmd,
-        _ => return Err(Unimplemented("Unsupported command")),
-    };
 
     let requested_chain = cmd.chain_id;
     let chain = ctx

--- a/crates/tx-relay/src/evm/vanchor.rs
+++ b/crates/tx-relay/src/evm/vanchor.rs
@@ -26,22 +26,19 @@ pub async fn handle_vanchor_relay_tx<'a>(
     ctx: RelayerContext,
     cmd: EvmCommand,
     stream: CommandStream,
-) {
+) -> Result<(), CommandResponse> {
     use CommandResponse::*;
     let cmd = match cmd {
         EvmCommand::VAnchor(cmd) => cmd,
-        _ => return,
+        _ => return Err(Unimplemented("Unsupported command")),
     };
 
     let requested_chain = cmd.chain_id;
-    let chain = match ctx.config.evm.get(&requested_chain.to_string()) {
-        Some(v) => v,
-        None => {
-            tracing::warn!("Unsupported Chain: {}", requested_chain);
-            let _ = stream.send(Network(NetworkStatus::UnsupportedChain)).await;
-            return;
-        }
-    };
+    let chain = ctx
+        .config
+        .evm
+        .get(&requested_chain.to_string())
+        .ok_or(Network(NetworkStatus::UnsupportedChain))?;
     let supported_contracts: HashMap<_, _> = chain
         .contracts
         .iter()
@@ -53,51 +50,28 @@ pub async fn handle_vanchor_relay_tx<'a>(
         .map(|c| (c.common.address, c))
         .collect();
     // get the contract configuration
-    let contract_config = match supported_contracts.get(&cmd.id) {
-        Some(config) => config,
-        None => {
-            tracing::warn!("Unsupported Contract: {:?}", cmd.id);
-            let _ = stream
-                .send(Network(NetworkStatus::UnsupportedContract))
-                .await;
-            return;
-        }
-    };
+    let contract_config = supported_contracts
+        .get(&cmd.id)
+        .ok_or(Network(NetworkStatus::UnsupportedContract))?;
 
-    let wallet = match ctx.evm_wallet(&cmd.chain_id.to_string()).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!("Misconfigured Network: {}", e);
-            let _ = stream
-                .send(Error(format!(
-                    "Misconfigured Network: {:?}",
-                    cmd.chain_id
-                )))
-                .await;
-            return;
-        }
-    };
+    let wallet =
+        ctx.evm_wallet(&cmd.chain_id.to_string())
+            .await
+            .map_err(|e| {
+                Error(format!("Misconfigured Network: {:?}, {e}", cmd.chain_id))
+            })?;
     // validate the relayer address first before trying
     // send the transaction.
-    let reward_address = match chain.beneficiary {
-        Some(account) => account,
-        None => wallet.address(),
-    };
+    let reward_address = chain.beneficiary.unwrap_or(wallet.address());
 
     if cmd.ext_data.relayer != reward_address {
-        let _ = stream
-            .send(Network(NetworkStatus::InvalidRelayerAddress))
-            .await;
-        return;
+        return Err(Network(NetworkStatus::InvalidRelayerAddress));
     }
 
     // validate that the roots are multiple of 32s
     let roots = cmd.proof_data.roots.to_vec();
     if roots.len() % 32 != 0 {
-        let _ = stream
-            .send(Withdraw(WithdrawStatus::InvalidMerkleRoots))
-            .await;
-        return;
+        return Err(Withdraw(WithdrawStatus::InvalidMerkleRoots));
     }
 
     tracing::debug!(
@@ -106,19 +80,15 @@ pub async fn handle_vanchor_relay_tx<'a>(
         chain.http_endpoint
     );
     let _ = stream.send(Network(NetworkStatus::Connecting)).await;
-    let provider = match ctx.evm_provider(&cmd.chain_id.to_string()).await {
-        Ok(value) => {
-            let _ = stream.send(Network(NetworkStatus::Connected)).await;
-            value
-        }
-        Err(e) => {
-            let reason = e.to_string();
-            let _ =
-                stream.send(Network(NetworkStatus::Failed { reason })).await;
-            let _ = stream.send(Network(NetworkStatus::Disconnected)).await;
-            return;
-        }
-    };
+    let provider =
+        ctx.evm_provider(&cmd.chain_id.to_string())
+            .await
+            .map_err(|e| {
+                Network(NetworkStatus::Failed {
+                    reason: e.to_string(),
+                })
+            })?;
+    let _ = stream.send(Network(NetworkStatus::Connected)).await;
 
     let client = Arc::new(SignerMiddleware::new(provider, wallet));
     let contract = VAnchorContract::new(cmd.id, client.clone());
@@ -165,59 +135,44 @@ pub async fn handle_vanchor_relay_tx<'a>(
         encryptions,
     );
 
-    let gas_amount = match client.estimate_gas(&call.tx, None).await {
-        Ok(value) => value,
-        Err(e) => {
-            let reason = e.to_string();
-            let _ =
-                stream.send(Network(NetworkStatus::Failed { reason })).await;
-            let _ = stream.send(Network(NetworkStatus::Disconnected)).await;
-            return;
-        }
-    };
+    let gas_amount =
+        client.estimate_gas(&call.tx, None).await.map_err(|e| {
+            Network(NetworkStatus::Failed {
+                reason: e.to_string(),
+            })
+        })?;
     let typed_chain_id = TypedChainId::Evm(chain.chain_id);
-    let fee_info = match get_fee_info(
+    let fee_info = get_fee_info(
         typed_chain_id,
         contract_config.common.address,
         gas_amount,
         &ctx,
     )
     .await
-    {
-        Ok(value) => value,
-        Err(e) => {
-            let reason = e.to_string();
-            let _ =
-                stream.send(Network(NetworkStatus::Failed { reason })).await;
-            let _ = stream.send(Network(NetworkStatus::Disconnected)).await;
-            return;
-        }
-    };
+    .map_err(|e| {
+        Network(NetworkStatus::Failed {
+            reason: e.to_string(),
+        })
+    })?;
 
     // validate refund amount
     if cmd.ext_data.refund > fee_info.max_refund {
-        tracing::error!(
-            "User requested a refund which is higher than the maximum"
-        );
         let msg = format!(
             "User requested a refund which is higher than the maximum of {}",
             fee_info.max_refund
         );
-        let _ = stream.send(Error(msg)).await;
-        return;
+        return Err(Error(msg));
     }
 
     // check the fee
     // TODO: This adjustment could potentially be exploited
     let adjusted_fee = fee_info.estimated_fee / 100 * 98;
     if cmd.ext_data.fee < adjusted_fee {
-        tracing::error!("Received a fee lower than expected");
         let msg = format!(
             "User sent a fee that is too low {} but expected {}",
             cmd.ext_data.fee, fee_info.estimated_fee
         );
-        let _ = stream.send(Error(msg)).await;
-        return;
+        return Err(Error(msg));
     }
 
     let target_system = TargetSystem::new_contract_address(
@@ -227,7 +182,7 @@ pub async fn handle_vanchor_relay_tx<'a>(
 
     tracing::trace!("About to send Tx to {:?} Chain", cmd.chain_id);
     handle_evm_tx(call, stream, cmd.chain_id, ctx.metrics.clone(), resource_id)
-        .await;
+        .await?;
 
     // update metric
     let metrics_clone = ctx.metrics.clone();
@@ -245,4 +200,5 @@ pub async fn handle_vanchor_relay_tx<'a>(
     metrics
         .total_fee_earned
         .inc_by(cmd.ext_data.fee.as_u64() as f64);
+    Ok(())
 }

--- a/crates/tx-relay/src/substrate/mixer.rs
+++ b/crates/tx-relay/src/substrate/mixer.rs
@@ -6,7 +6,7 @@ use webb::substrate::{
     subxt::{tx::PairSigner, SubstrateConfig},
 };
 use webb_relayer_context::RelayerContext;
-use webb_relayer_handler_utils::SubstrateCommand;
+use webb_relayer_handler_utils::SubstrateMixerCommand;
 
 /// Handler for Substrate Mixer commands
 ///
@@ -17,15 +17,10 @@ use webb_relayer_handler_utils::SubstrateCommand;
 /// * `stream` - The stream to write the response to
 pub async fn handle_substrate_mixer_relay_tx<'a>(
     ctx: RelayerContext,
-    cmd: SubstrateCommand,
+    cmd: SubstrateMixerCommand,
     stream: CommandStream,
 ) -> Result<(), CommandResponse> {
     use CommandResponse::*;
-
-    let cmd = match cmd {
-        SubstrateCommand::Mixer(cmd) => cmd,
-        _ => return Err(Unimplemented("Unsupported command")),
-    };
 
     let root_element = Element(cmd.root);
     let nullifier_hash_element = Element(cmd.nullifier_hash);

--- a/crates/tx-relay/src/substrate/mixer.rs
+++ b/crates/tx-relay/src/substrate/mixer.rs
@@ -19,43 +19,31 @@ pub async fn handle_substrate_mixer_relay_tx<'a>(
     ctx: RelayerContext,
     cmd: SubstrateCommand,
     stream: CommandStream,
-) {
+) -> Result<(), CommandResponse> {
     use CommandResponse::*;
 
     let cmd = match cmd {
         SubstrateCommand::Mixer(cmd) => cmd,
-        _ => return,
+        _ => return Err(Unimplemented("Unsupported command")),
     };
 
     let root_element = Element(cmd.root);
     let nullifier_hash_element = Element(cmd.nullifier_hash);
 
     let requested_chain = cmd.chain_id;
-    let maybe_client = ctx
+    let client = ctx
         .substrate_provider::<SubstrateConfig>(&requested_chain.to_string())
-        .await;
-    let client = match maybe_client {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!("Error while getting Substrate client: {}", e);
-            let _ = stream.send(Error(format!("{e}"))).await;
-            return;
-        }
-    };
+        .await
+        .map_err(|e| {
+            Error(format!("Error while getting Substrate client: {e}"))
+        })?;
 
-    let pair = match ctx.substrate_wallet(&cmd.chain_id.to_string()).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!("Misconfigured Network: {}", e);
-            let _ = stream
-                .send(Error(format!(
-                    "Misconfigured Network: {:?}",
-                    cmd.chain_id
-                )))
-                .await;
-            return;
-        }
-    };
+    let pair = ctx
+        .substrate_wallet(&cmd.chain_id.to_string())
+        .await
+        .map_err(|e| {
+            Error(format!("Misconfigured Network {:?}: {e}", cmd.chain_id))
+        })?;
 
     let signer = PairSigner::new(pair);
 
@@ -75,14 +63,9 @@ pub async fn handle_substrate_mixer_relay_tx<'a>(
         .sign_and_submit_then_watch_default(&withdraw_tx, &signer)
         .await;
 
-    let event_stream = match withdraw_tx_hash {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("Error while sending Tx: {}", e);
-            let _ = stream.send(Error(format!("{e}"))).await;
-            return;
-        }
-    };
+    let event_stream = withdraw_tx_hash
+        .map_err(|e| Error(format!("Error while sending Tx: {e}")))?;
 
-    handle_substrate_tx(event_stream, stream, cmd.chain_id).await;
+    handle_substrate_tx(event_stream, stream, cmd.chain_id).await?;
+    Ok(())
 }

--- a/crates/tx-relay/src/substrate/vanchor.rs
+++ b/crates/tx-relay/src/substrate/vanchor.rs
@@ -12,7 +12,7 @@ use webb_proposals::{
     ResourceId, SubstrateTargetSystem, TargetSystem, TypedChainId,
 };
 use webb_relayer_context::RelayerContext;
-use webb_relayer_handler_utils::SubstrateCommand;
+use webb_relayer_handler_utils::SubstrateVAchorCommand;
 use webb_relayer_utils::metric::Metrics;
 
 /// Handler for Substrate Anchor commands
@@ -24,14 +24,10 @@ use webb_relayer_utils::metric::Metrics;
 /// * `stream` - The stream to write the response to
 pub async fn handle_substrate_vanchor_relay_tx<'a>(
     ctx: RelayerContext,
-    cmd: SubstrateCommand,
+    cmd: SubstrateVAchorCommand,
     stream: CommandStream,
 ) -> Result<(), CommandResponse> {
     use CommandResponse::*;
-    let cmd = match cmd {
-        SubstrateCommand::VAnchor(cmd) => cmd,
-        _ => return Err(Unimplemented("Unsupported command")),
-    };
 
     let proof_elements: vanchor::ProofData<Element> = vanchor::ProofData {
         proof: cmd.proof_data.proof,

--- a/crates/tx-relay/src/substrate/vanchor.rs
+++ b/crates/tx-relay/src/substrate/vanchor.rs
@@ -26,11 +26,11 @@ pub async fn handle_substrate_vanchor_relay_tx<'a>(
     ctx: RelayerContext,
     cmd: SubstrateCommand,
     stream: CommandStream,
-) {
+) -> Result<(), CommandResponse> {
     use CommandResponse::*;
     let cmd = match cmd {
         SubstrateCommand::VAnchor(cmd) => cmd,
-        _ => return,
+        _ => return Err(Unimplemented("Unsupported command")),
     };
 
     let proof_elements: vanchor::ProofData<Element> = vanchor::ProofData {
@@ -67,28 +67,16 @@ pub async fn handle_substrate_vanchor_relay_tx<'a>(
     let maybe_client = ctx
         .substrate_provider::<SubstrateConfig>(&requested_chain.to_string())
         .await;
-    let client = match maybe_client {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!("Error while getting Substrate client: {}", e);
-            let _ = stream.send(Error(format!("{e}"))).await;
-            return;
-        }
-    };
+    let client = maybe_client.map_err(|e| {
+        Error(format!("Error while getting Substrate client: {e}"))
+    })?;
 
-    let pair = match ctx.substrate_wallet(&cmd.chain_id.to_string()).await {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!("Misconfigured Network: {}", e);
-            let _ = stream
-                .send(Error(format!(
-                    "Misconfigured Network: {:?}",
-                    cmd.chain_id
-                )))
-                .await;
-            return;
-        }
-    };
+    let pair = ctx
+        .substrate_wallet(&cmd.chain_id.to_string())
+        .await
+        .map_err(|e| {
+            Error(format!("Misconfigured Network {:?}: {e}", cmd.chain_id))
+        })?;
 
     let signer = PairSigner::new(pair);
 
@@ -102,31 +90,21 @@ pub async fn handle_substrate_vanchor_relay_tx<'a>(
         .sign_and_submit_then_watch_default(&transact_tx, &signer)
         .await;
 
-    let event_stream = match transact_tx_hash {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("Error while sending Tx: {}", e);
-            let _ = stream.send(Error(format!("{e}"))).await;
-            return;
-        }
-    };
+    let event_stream = transact_tx_hash
+        .map_err(|e| Error(format!("Error while sending Tx: {e}")))?;
 
-    handle_substrate_tx(event_stream, stream, cmd.chain_id).await;
+    handle_substrate_tx(event_stream, stream, cmd.chain_id).await?;
 
-    let target = {
-        let metadata = client.metadata();
-        let pallet = metadata.pallet("VAnchorHandlerBn254");
-        match pallet {
-            Ok(pallet) => SubstrateTargetSystem::builder()
+    let target = client
+        .metadata()
+        .pallet("VAnchorHandlerBn254")
+        .map(|pallet| {
+            SubstrateTargetSystem::builder()
                 .pallet_index(pallet.index())
                 .tree_id(cmd.id)
-                .build(),
-            Err(e) => {
-                tracing::error!("Vanchor handler pallet not found: {}", e);
-                return;
-            }
-        }
-    };
+                .build()
+        })
+        .map_err(|e| Error(format!("Vanchor handler pallet not found: {e}")))?;
 
     let target_system = TargetSystem::Substrate(target);
     let typed_chain_id = TypedChainId::Substrate(cmd.chain_id as u32);
@@ -146,4 +124,5 @@ pub async fn handle_substrate_vanchor_relay_tx<'a>(
         .inc_by(cmd.ext_data.fee as f64);
     // update metric for total fee earned by relayer
     metrics.total_fee_earned.inc_by(cmd.ext_data.fee as f64);
+    Ok(())
 }


### PR DESCRIPTION
## Summary of changes
- Clean up error handling in tx-relay to use Result and `?` operator. This simplifies control flow and makes the code much more readable. However its far from perfect as the "error" type used is `CommandResponse` which is also used for success messages. In relayer v2 we should add a separate `ErrorResponse` type.
- Clean up Substrate/Evm command types so they can be checked at compile time and dont throw any runtime error.


### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [x] Tested
- [x] Documented
