### PR TITLE
sync blocks from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ webb-relayer -vv -c ./config
 | `withdraw-config`          | Config the fees and gas limits of your private transaction relayer.                        | Optional    |
 | `proposal-signing-backend` | a value of `ProposalSigingBackend` (for example `{ type = "DKGNode", node = "dkg-node" }`) | Optional    |
 
+#### Event Watcher Configuration
+
+| Field                      | Description                                                                                | Optionality |
+| -------------------------- | ------------------------------------------------------------------------------------------ | ----------- |
+| `enabled`                  | Boolean value. Default set to `true`                                                       | Optional    |
+| `polling-interval`         | Interval between polling next block in millisecond. Default value  is `3000ms`               | Optional    |
+| `print-progress-interval`  | Interval between printing sync progress in millisecond. Default value is `7000ms`            | Optional    |
+| `sync-blocks-from`         | Block number from which relayer will start syncing. Default will be `latest` block number    | Optional    |
+
+
 ### Docker 🐳
 
 To use Docker to run the relayer, you will need to specify a config file and provide an `.env` file as described above. Then proceed to save it into the `config` directory.

--- a/crates/event-watcher-traits/src/substrate/event_watcher.rs
+++ b/crates/event-watcher-traits/src/substrate/event_watcher.rs
@@ -121,7 +121,7 @@ pub trait SubstrateEventWatcher {
                     current_block_number
                 );
                 let sync_blocks_from: u64 = event_watcher_config
-                    .sync_blocks_form
+                    .sync_blocks_from
                     .unwrap_or(current_block_number);
                 // get latest saved block number
                 let block = store

--- a/crates/event-watcher-traits/src/substrate/event_watcher.rs
+++ b/crates/event-watcher-traits/src/substrate/event_watcher.rs
@@ -227,7 +227,6 @@ pub trait SubstrateEventWatcher {
                     );
                     tokio::time::sleep(duration).await;
                 }
-                // only print the progress if 7 seconds (by default) is passed.
                 let print_progress_interval = Duration::from_millis(
                     event_watcher_config.print_progress_interval,
                 );

--- a/crates/event-watcher-traits/src/tests.rs
+++ b/crates/event-watcher-traits/src/tests.rs
@@ -17,6 +17,7 @@ use tokio::sync::Mutex;
 use webb::substrate::dkg_runtime::api::system;
 use webb::substrate::subxt::{OnlineClient, PolkadotConfig};
 use webb::substrate::{dkg_runtime, subxt};
+use webb_relayer_config::event_watcher::EventsWatcherConfig;
 use webb_relayer_context::RelayerContext;
 use webb_relayer_store::sled::SledStore;
 use webb_relayer_utils::metric;
@@ -63,7 +64,6 @@ impl SubstrateEventWatcher for RemarkedEventWatcher {
 #[ignore = "need to be run manually"]
 async fn substrate_event_watcher_should_work() -> webb_relayer_utils::Result<()>
 {
-    let node_name = String::from("test-node");
     let chain_id = 5u32;
     let store = SledStore::temporary()?;
     let client = OnlineClient::<PolkadotConfig>::new().await?;
@@ -71,8 +71,15 @@ async fn substrate_event_watcher_should_work() -> webb_relayer_utils::Result<()>
     let config = webb_relayer_config::WebbRelayerConfig::default();
     let ctx = RelayerContext::new(config, store.clone());
     let metrics = ctx.metrics.clone();
+    let event_watcher_config = EventsWatcherConfig::default();
     watcher
-        .run(node_name, chain_id, client.into(), Arc::new(store), metrics)
+        .run(
+            chain_id,
+            client.into(),
+            Arc::new(store),
+            metrics,
+            event_watcher_config,
+        )
         .await?;
     Ok(())
 }

--- a/crates/relayer-config/src/event_watcher.rs
+++ b/crates/relayer-config/src/event_watcher.rs
@@ -18,9 +18,12 @@ pub struct EventsWatcherConfig {
     pub max_blocks_per_step: u64,
     /// print sync progress frequency in milliseconds
     /// if it is zero, means no progress will be printed.
-    #[serde(skip_serializing, default = "print_progress_interval_default")]
+    #[serde(
+        rename(serialize = "printProgressInterval"),
+        default = "print_progress_interval_default"
+    )]
     pub print_progress_interval: u64,
-    /// Sync block from
+    /// Sync blocks from
     #[serde(rename(serialize = "syncBlocksFrom"))]
-    pub sync_blocks_form: Option<u64>,
+    pub sync_blocks_from: Option<u64>,
 }

--- a/crates/relayer-config/src/event_watcher.rs
+++ b/crates/relayer-config/src/event_watcher.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// EventsWatchConfig is the configuration for the events watch.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Copy)]
 #[serde(rename_all = "kebab-case")]
 pub struct EventsWatcherConfig {
     /// A flag for enabling API endpoints for querying data from the relayer.
@@ -20,4 +20,7 @@ pub struct EventsWatcherConfig {
     /// if it is zero, means no progress will be printed.
     #[serde(skip_serializing, default = "print_progress_interval_default")]
     pub print_progress_interval: u64,
+    /// Sync block from
+    #[serde(rename(serialize = "syncBlocksFrom"))]
+    pub sync_blocks_form: Option<u64>,
 }

--- a/services/webb-relayer/src/service.rs
+++ b/services/webb-relayer/src/service.rs
@@ -226,7 +226,6 @@ pub async fn ignite(
                                 ctx,
                                 config,
                                 client.clone(),
-                                node_name.to_owned(),
                                 chain_id,
                                 store.clone(),
                             )?;
@@ -236,7 +235,6 @@ pub async fn ignite(
                                 ctx,
                                 config,
                                 client.clone(),
-                                node_name.to_owned(),
                                 chain_id,
                                 store.clone(),
                             )?;
@@ -271,7 +269,6 @@ pub async fn ignite(
                                 ctx,
                                 config,
                                 client.clone(),
-                                node_name.to_owned(),
                                 chain_id,
                                 store.clone(),
                             )?;
@@ -281,7 +278,6 @@ pub async fn ignite(
                                 ctx.clone(),
                                 config,
                                 client.clone(),
-                                node_name.to_owned(),
                                 chain_id,
                                 store.clone(),
                             )
@@ -320,27 +316,25 @@ pub async fn ignite(
 /// * `ctx` - RelayContext reference that holds the configuration
 /// * `config` - VAnchorBn254 configuration
 /// * `client` - WebbProtocol client
-/// * `node_name` - Name of the node
 /// * `chain_id` - An u32 representing the chain id of the chain
 /// * `store` -[Sled](https://sled.rs)-based database store
 pub fn start_substrate_vanchor_event_watcher(
     ctx: &RelayerContext,
     config: &VAnchorBn254PalletConfig,
     client: WebbProtocolClient,
-    node_name: String,
     chain_id: u32,
     store: Arc<Store>,
 ) -> crate::Result<()> {
     if !config.events_watcher.enabled {
         tracing::warn!(
             "Substrate VAnchor events watcher is disabled for ({}).",
-            node_name,
+            chain_id,
         );
         return Ok(());
     }
     tracing::debug!(
         "Substrate VAnchor events watcher for ({}) Started.",
-        node_name,
+        chain_id,
     );
 
     let my_ctx = ctx.clone();
@@ -350,11 +344,11 @@ pub fn start_substrate_vanchor_event_watcher(
     let task = async move {
         let watcher = SubstrateVAnchorLeavesWatcher::default();
         let substrate_leaves_watcher_task = watcher.run(
-            node_name.to_owned(),
             chain_id,
             client.clone().into(),
             store.clone(),
             metrics.clone(),
+            my_config.events_watcher,
         );
         let proposal_signing_backend = make_substrate_proposal_signing_backend(
             &my_ctx,
@@ -374,29 +368,29 @@ pub fn start_substrate_vanchor_event_watcher(
                     my_config.linked_anchors.unwrap(),
                 );
                 let substrate_vanchor_watcher_task = watcher.run(
-                    node_name.to_owned(),
                     chain_id,
                     client.clone().into(),
                     store.clone(),
                     metrics.clone(),
+                    my_config.events_watcher,
                 );
                 tokio::select! {
                     _ = substrate_vanchor_watcher_task => {
                         tracing::warn!(
                             "Substrate VAnchor watcher (DKG Backend) task stopped for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                     _ = substrate_leaves_watcher_task => {
                         tracing::warn!(
                             "Substrate VAnchor leaves watcher stopped for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                     _ = shutdown_signal.recv() => {
                         tracing::trace!(
                             "Stopping Substrate VAnchor watcher (DKG Backend) for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                 }
@@ -409,29 +403,29 @@ pub fn start_substrate_vanchor_event_watcher(
                     my_config.linked_anchors.unwrap(),
                 );
                 let substrate_vanchor_watcher_task = watcher.run(
-                    node_name.to_owned(),
                     chain_id,
                     client.into(),
                     store.clone(),
                     metrics.clone(),
+                    my_config.events_watcher,
                 );
                 tokio::select! {
                     _ = substrate_vanchor_watcher_task => {
                         tracing::warn!(
                             "Substrate VAnchor watcher (Mocked Backend) task stopped for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                     _ = substrate_leaves_watcher_task => {
                         tracing::warn!(
                             "Substrate VAnchor leaves watcher stopped for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                     _ = shutdown_signal.recv() => {
                         tracing::trace!(
                             "Stopping Substrate VAnchor watcher (Mocked Backend) for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                 }
@@ -441,13 +435,13 @@ pub fn start_substrate_vanchor_event_watcher(
                     _ = substrate_leaves_watcher_task => {
                         tracing::warn!(
                             "Substrate VAnchor leaves watcher stopped for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                     _ = shutdown_signal.recv() => {
                         tracing::trace!(
                             "Stopping Substrate VAnchor watcher (Mocked Backend) for ({})",
-                            node_name,
+                            chain_id,
                         );
                     },
                 }
@@ -469,14 +463,12 @@ pub fn start_substrate_vanchor_event_watcher(
 /// * `ctx` - RelayContext reference that holds the configuration
 /// * `config` - DKG proposal handler configuration
 /// * `client` - DKG client
-/// * `node_name` - Name of the node
 /// * `chain_id` - An u32 representing the chain id of the chain
 /// * `store` -[Sled](https://sled.rs)-based database store
 pub fn start_dkg_proposal_handler(
     ctx: &RelayerContext,
     config: &DKGProposalHandlerPalletConfig,
     client: DkgClient,
-    node_name: String,
     chain_id: u32,
     store: Arc<Store>,
 ) -> crate::Result<()> {
@@ -484,37 +476,37 @@ pub fn start_dkg_proposal_handler(
     if !config.events_watcher.enabled {
         tracing::warn!(
             "DKG Proposal Handler events watcher is disabled for ({}).",
-            node_name,
+            chain_id,
         );
         return Ok(());
     }
     tracing::debug!(
         "DKG Proposal Handler events watcher for ({}) Started.",
-        node_name,
+        chain_id,
     );
-    let node_name2 = node_name.clone();
     let mut shutdown_signal = ctx.shutdown_signal();
     let metrics = ctx.metrics.clone();
+    let my_config = config.clone();
     let task = async move {
         let proposal_handler = ProposalHandlerWatcher::default();
         let watcher = proposal_handler.run(
-            node_name,
             chain_id,
             client.into(),
             store,
             metrics,
+            my_config.events_watcher,
         );
         tokio::select! {
             _ = watcher => {
                 tracing::warn!(
                     "DKG Proposal Handler events watcher stopped for ({})",
-                    node_name2,
+                    chain_id,
                 );
             },
             _ = shutdown_signal.recv() => {
                 tracing::trace!(
                     "Stopping DKG Proposal Handler events watcher for ({})",
-                    node_name2,
+                    chain_id,
                 );
             },
         }
@@ -533,14 +525,12 @@ pub fn start_dkg_proposal_handler(
 /// * `ctx` - RelayContext reference that holds the configuration
 /// * `config` - DKG pallet configuration
 /// * `client` - DKG client
-/// * `node_name` - Name of the node
 /// * `chain_id` - An u32 representing the chain id of the chain
 /// * `store` -[Sled](https://sled.rs)-based database store
 pub fn start_dkg_pallet_watcher(
     ctx: &RelayerContext,
     config: &DKGPalletConfig,
     client: DkgClient,
-    node_name: String,
     chain_id: u32,
     store: Arc<Store>,
 ) -> crate::Result<()> {
@@ -548,35 +538,35 @@ pub fn start_dkg_pallet_watcher(
     if !config.events_watcher.enabled {
         tracing::warn!(
             "DKG Pallet events watcher is disabled for ({}).",
-            node_name,
+            chain_id,
         );
         return Ok(());
     }
-    tracing::debug!("DKG Pallet events watcher for ({}) Started.", node_name,);
-    let node_name2 = node_name.clone();
+    tracing::debug!("DKG Pallet events watcher for ({}) Started.", chain_id,);
     let mut shutdown_signal = ctx.shutdown_signal();
     let webb_config = ctx.config.clone();
     let metrics = ctx.metrics.clone();
+    let my_config = config.clone();
     let task = async move {
         let governor_watcher = DKGGovernorWatcher::new(webb_config);
         let watcher = governor_watcher.run(
-            node_name,
             chain_id,
             client.into(),
             store,
             metrics,
+            my_config.events_watcher,
         );
         tokio::select! {
             _ = watcher => {
                 tracing::warn!(
                     "DKG Pallet events watcher stopped for ({})",
-                    node_name2,
+                    chain_id,
                 );
             },
             _ = shutdown_signal.recv() => {
                 tracing::trace!(
                     "Stopping DKG Pallet events watcher for ({})",
-                    node_name2,
+                    chain_id,
                 );
             },
         }
@@ -940,31 +930,31 @@ pub async fn start_substrate_signature_bridge_events_watcher(
     ctx: RelayerContext,
     config: &SignatureBridgePalletConfig,
     client: WebbProtocolClient,
-    node_name: String,
     chain_id: u32,
     store: Arc<Store>,
 ) -> crate::Result<()> {
     if !config.events_watcher.enabled {
         tracing::warn!(
             "Substrate Signature Bridge events watcher is disabled for ({}).",
-            node_name,
+            chain_id,
         );
         return Ok(());
     }
     let mut shutdown_signal = ctx.shutdown_signal();
+    let my_config = config.clone();
     let task = async move {
         tracing::debug!(
             "Substrate Signature Bridge watcher for ({}) Started.",
-            node_name
+            chain_id
         );
         let substrate_bridge_watcher = SubstrateBridgeEventWatcher::default();
         let events_watcher_task = SubstrateEventWatcher::run(
             &substrate_bridge_watcher,
-            node_name.to_owned(),
             chain_id,
             client.clone().into(),
             store.clone(),
             ctx.metrics.clone(),
+            my_config.events_watcher,
         );
         let cmd_handler_task = SubstrateBridgeWatcher::run(
             &substrate_bridge_watcher,
@@ -976,19 +966,19 @@ pub async fn start_substrate_signature_bridge_events_watcher(
             _ = events_watcher_task => {
                 tracing::warn!(
                     "Substrate signature bridge events watcher task stopped for ({})",
-                    node_name
+                    chain_id
                 );
             },
             _ = cmd_handler_task => {
                 tracing::warn!(
                     "Substrate signature bridge cmd handler task stopped for ({})",
-                    node_name
+                    chain_id
                 );
             },
             _ = shutdown_signal.recv() => {
                 tracing::trace!(
                     "Stopping Substrate Signature Bridge watcher for ({})",
-                    node_name,
+                    chain_id,
                 );
             },
         }

--- a/tests/lib/localDkg.ts
+++ b/tests/lib/localDkg.ts
@@ -194,6 +194,8 @@ export class LocalDkg extends SubstrateNodeBase<TypedEvent> {
           'events-watcher': {
             enabled: c.eventsWatcher.enabled,
             'polling-interval': c.eventsWatcher.pollingInterval,
+            'print-progress-interval' : c.eventsWatcher.printProgressInterval,
+            'sync-blocks-from': c.eventsWatcher.syncBlocksFrom
           },
         };
         return convertedPallet;

--- a/tests/lib/localProtocolSubstrate.ts
+++ b/tests/lib/localProtocolSubstrate.ts
@@ -178,6 +178,8 @@ export class LocalProtocolSubstrate extends BaseLocalSubstrate {
           'events-watcher': {
             enabled: c.eventsWatcher.enabled,
             'polling-interval': c.eventsWatcher.pollingInterval,
+            'print-progress-interval' : c.eventsWatcher.printProgressInterval,
+            'sync-blocks-from': c.eventsWatcher.syncBlocksFrom
           },
           'proposal-signing-backend':
             c.proposalSigningBackend?.type === 'Mocked'

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -5,6 +5,8 @@ import { EventsWatcher } from './webbRelayer';
 export const defaultEventsWatcherValue: EventsWatcher = {
   enabled: true,
   pollingInterval: 3000,
+  printProgressInterval: 7000,
+  syncBlocksFrom: 1
 };
 
 // Pad hexString with zero to make it of length 64.

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -656,6 +656,7 @@ export interface EventsWatcher {
   enabled: boolean;
   pollingInterval: number;
   printProgressInterval?: number;
+  syncBlocksFrom?: number;
 }
 
 export type RawResourceId = {


### PR DESCRIPTION
## Summary of changes
- Add config to set custom block number for a relayer to start syncing
```rust
     pub struct EventsWatcherConfig {
          /// if it is enabled for this chain or not.
          pub enabled: bool,
          .
          /// Sync blocks from
          #[serde(rename(serialize = "syncBlocksFrom"))]
          pub sync_blocks_from: Option<u64>,
     }
```
  ```rust
    let sync_blocks_from: u64 = event_watcher_config
          .sync_blocks_from
          .unwrap_or(current_block_number);
    // get latest saved block number
    let block = store
          .get_last_block_number(history_store_key, sync_blocks_from)
          .map_err(Into::into)
          .map_err(backoff::Error::transient)?;
  ```
- Use `print-progress-interval` from config

### Reference issue to close (if applicable)
- Closes #345 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
