### PR TITLE
Use workspace inheritance (fixes #348)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6326,7 +6326,6 @@ dependencies = [
  "dotenv",
  "ethereum-types 0.14.1",
  "futures",
- "native-tls",
  "paw",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
-[profile.release]
-strip = "symbols"
-lto = "thin"
-
-[profile.dev]
-strip = "symbols"
-debug = 0
+[workspace.package]
+authors = ["Webb Developers <drew@webb.tools>"]
+license = "Apache-2.0"
+documentation = "https://docs.rs/webb-relayer"
+homepage = "https://webb.tools"
+repository = "https://github.com/webb-tools/relayer"
+edition = "2021"
 
 [workspace]
 members = [
@@ -13,3 +13,52 @@ members = [
     "event-watchers/*",
     "services/*",
 ]
+
+[workspace.dependencies]
+webb-proposal-signing-backends = { path = "crates/proposal-signing-backends" }
+webb-relayer-tx-queue = { path = "crates/tx-queue" }
+webb-relayer-handlers = { path = "crates/relayer-handlers" }
+webb-relayer-store = { path = "crates/relayer-store" }
+webb-relayer-config = { path = "crates/relayer-config" }
+webb-relayer-context = { path = "crates/relayer-context" }
+webb-relayer-utils = { path = "crates/relayer-utils"}
+webb-event-watcher-traits = { path = "crates/event-watcher-traits"}
+webb-ew-dkg = { path = "event-watchers/dkg" }
+webb-ew-evm = { path = "event-watchers/evm" }
+webb-ew-substrate = { path = "event-watchers/substrate" }
+webb-relayer-handler-utils = { path = "crates/relayer-handler-utils" }
+webb-relayer-types = { path = "crates/relayer-types" }
+webb-relayer = { path = "services/webb-relayer" }
+
+anyhow = "^1"
+tracing = { version = "^0.1", features = ["log"] }
+url = { version = "^2.3", features = ["serde"] }
+sled = "^0.34"
+tokio = { version = "^1", features = ["full"] }
+config = { version = "0.13", default-features = false, features = ["toml", "json"] }
+serde_json = { version = "^1", default-features = false }
+paw = { version = "^1.0" }
+webb = { version = "0.5.14", default-features = false }
+# Used by ethers (but we need it to be vendored with the lib).
+native-tls = { version = "^0.2", features = ["vendored"] }
+webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
+ethereum-types = "0.14.1"
+dotenv = "0.15.0"
+axum = { version = "0.6.4", features = ["ws"] }
+tempfile = "^3.3"
+async-trait = "^0.1"
+futures = { version = "^0.3", default-features = false }
+backoff = { version = "0.4.0", features = ["tokio"] }
+hex = { version = "0.4", default-features = false }
+libsecp256k1 = "0.7.1"
+serde = { version = "^1", default-features = false, features = ["derive"] }
+glob = "^0.3"
+serde_path_to_error = "0.1.9"
+
+[profile.release]
+strip = "symbols"
+lto = "thin"
+
+[profile.dev]
+strip = "symbols"
+debug = 0

--- a/crates/event-watcher-traits/Cargo.toml
+++ b/crates/event-watcher-traits/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "webb-event-watcher-traits"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,17 +15,19 @@ webb-relayer-store = { path = "../relayer-store" }
 webb-relayer-config = { path = "../relayer-config" }
 webb-relayer-context = { path = "../relayer-context" }
 webb-relayer-utils = { path = "../relayer-utils" }
-async-trait = "^0.1"
-tracing = { version = "^0.1", features = ["log"] }
+
+async-trait = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+backoff = { workspace = true }
+tokio = { workspace = true }
+webb = { workspace = true }
+# Used by ethers (but we need it to be vendored with the lib).
+native-tls = { workspace = true }
+webb-proposals = { workspace = true }
+
 tracing-test = "0.2"
 sled = { version = "^0.34" }
-futures = { version = "^0.3", default-features = false }
-backoff = { version = "0.4.0", features = ["tokio"] }
-tokio = { version = "^1", features = ["full"] }
-webb = { version = "0.5.14", default-features = false }
-# Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
 
 [features]
 default = ["std", "evm", "substrate"]

--- a/crates/proposal-signing-backends/Cargo.toml
+++ b/crates/proposal-signing-backends/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "webb-proposal-signing-backends"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,17 +14,19 @@ edition = "2021"
 webb-relayer-types = { path = "../relayer-types" }
 webb-relayer-store = { path = "../relayer-store" }
 webb-relayer-utils = { path = "../relayer-utils" }
-async-trait = "^0.1"
-tracing = { version = "^0.1", features = ["log"] }
-sled = { version = "^0.34" }
-futures = { version = "^0.3", default-features = false }
-tokio = { version = "^1", features = ["full"] }
-hex = { version = "0.4", default-features = false }
-webb = { version = "0.5.14", default-features = false }
+
+async-trait = { workspace = true }
+tracing = { workspace = true }
+sled = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true }
+hex = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+ethereum-types = { workspace = true }
+
 typed-builder = "0.12.0"
 
 [features]

--- a/crates/relayer-config/Cargo.toml
+++ b/crates/relayer-config/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "webb-relayer-config"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,22 +14,24 @@ edition = "2021"
 webb-relayer-store = { path = "../relayer-store" }
 webb-relayer-types = { path = "../relayer-types" }
 webb-relayer-utils = { path = "../relayer-utils" }
-anyhow = { version = "^1", optional = true }
-tracing = { version = "^0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3.16", features = ["parking_lot", "env-filter"], optional = true }
-url = { version = "^2.3", features = ["serde"] }
-serde = { version = "^1", default-features = false, features = ["derive"] }
-config = { version = "0.13", default-features = false, features = ["toml", "json"] }
-serde_json = { version = "^1", default-features = false }
+
+anyhow = { workspace = true, optional = true }
+tracing = { workspace = true }
+url = { workspace = true }
+serde = { workspace = true }
+config = { workspace = true }
+serde_json = { workspace = true }
+webb = { workspace = true }
+# Used by ethers (but we need it to be vendored with the lib).
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+ethereum-types = { workspace = true }
+glob = { workspace = true }
+serde_path_to_error = { workspace = true }
+
 structopt = { version = "^0.3", features = ["paw"], optional = true }
 directories-next = { version = "^2.0", optional = true }
-webb = { version = "0.5.14", default-features = false }
-# Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
-glob = "^0.3"
-serde_path_to_error = "0.1.9"
+tracing-subscriber = { version = "0.3.16", features = ["parking_lot", "env-filter"], optional = true }
 
 [features]
 default = ["evm-runtime", "substrate-runtime", "cli"]

--- a/crates/relayer-context/Cargo.toml
+++ b/crates/relayer-context/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "webb-relayer-context"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,10 +14,12 @@ edition = "2021"
 webb-relayer-config = { path = "../relayer-config"}
 webb-relayer-utils = { path = "../relayer-utils"}
 webb-relayer-store = { path = "../relayer-store" }
-tokio = { version = "^1", features = ["full"] }
-webb = { version = "0.5.14", default-features = false }
+
+tokio = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
+native-tls = { workspace = true }
+
 coingecko = "1.0.1"
 ethers = {version = "1.0.2", features = ["rustls"] }
 

--- a/crates/relayer-handler-utils/Cargo.toml
+++ b/crates/relayer-handler-utils/Cargo.toml
@@ -1,14 +1,20 @@
 [package]
 name = "webb-relayer-handler-utils"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "^1", default-features = false, features = ["derive"] }
-tokio = { version = "^1", features = ["full"] }
 webb-relayer-tx-relay-utils = { path = "../tx-relay-utils" }
-webb = { version = "0.5.14", default-features = false }
+
+serde = { workspace = true }
+tokio = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
+native-tls = { workspace = true }

--- a/crates/relayer-handlers/Cargo.toml
+++ b/crates/relayer-handlers/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "webb-relayer-handlers"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,16 +17,19 @@ webb-relayer-store = { path = "../relayer-store" }
 webb-relayer-config = { path = "../relayer-config" }
 webb-relayer-context = { path = "../relayer-context" }
 webb-relayer-utils = { path = "../relayer-utils" }
-tracing = { version = "^0.1", features = ["log"] }
-futures = { version = "^0.3", default-features = false }
-serde = { version = "^1", default-features = false, features = ["derive"] }
-tokio = { version = "^1", features = ["full"] }
-tokio-stream = { version = "^0.1" }
-serde_json = { version = "^1", default-features = false }
-webb = { version = "0.5.14", default-features = false }
+
+tracing = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
-axum = { version = "0.6.4", features = ["ws"] }
+native-tls = { workspace = true }
+webb-proposals = { workspace = true }
+ethereum-types = { workspace = true }
+axum = { workspace = true }
+
 axum-client-ip = "0.4.0"
+tokio-stream = { version = "^0.1" }
+

--- a/crates/relayer-store/Cargo.toml
+++ b/crates/relayer-store/Cargo.toml
@@ -1,20 +1,27 @@
 [package]
 name = "webb-relayer-store"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-relayer-utils = { path = "../relayer-utils" }
-parking_lot = "^0.12"
-tracing = { version = "^0.1", features = ["log"] }
-sled = { version = "^0.34" }
-serde = { version = "^1", default-features = false, features = ["derive"] }
-serde_json = { version = "^1", default-features = false }
-hex = { version = "0.4", default-features = false }
-webb = { version = "0.5.14", default-features = false }
+webb-relayer-utils = { workspace = true }
+
+tracing = { workspace = true }
+sled = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-tempfile = "^3.3"
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+tempfile = { workspace = true }
+
+parking_lot = "^0.12"

--- a/crates/relayer-types/Cargo.toml
+++ b/crates/relayer-types/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
 name = "webb-relayer-types"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = { version = "^0.1", features = ["log"] }
-url = { version = "^2.3", features = ["serde"] }
-serde = { version = "^1", default-features = false, features = ["derive"] }
-webb = { version = "0.5.14", default-features = false }
+tracing = { workspace = true }
+url = { workspace = true }
+serde = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-ethereum-types = "0.14.1"
+native-tls = { workspace = true }
+ethereum-types = { workspace = true }
+
 tiny-bip39 = "1.0.0"

--- a/crates/relayer-utils/Cargo.toml
+++ b/crates/relayer-utils/Cargo.toml
@@ -1,29 +1,35 @@
 [package]
 name = "webb-relayer-utils"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex = "0.4"
-backoff = { version = "0.4.0", features = ["tokio"] }
-serde_path_to_error = "0.1.9"
-thiserror = "^1"
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-webb = { version = "0.5.14", default-features = false }
+hex = { workspace = true }
+backoff = { workspace = true }
+serde_path_to_error = { workspace = true }
+webb-proposals = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-glob = "^0.3"
-config = { version = "0.13", default-features = false, features = ["toml", "json"] }
-sled = { version = "^0.34" }
-libsecp256k1 = "0.7.1"
-url = { version = "^2.3", features = ["serde"] }
-serde_json = { version = "^1", default-features = false }
+native-tls = { workspace = true, optional = true }
+glob = { workspace = true }
+sled = { workspace = true }
+libsecp256k1 = { workspace = true }
+url = { workspace = true }
+serde_json = { workspace = true }
+axum = { workspace = true }
+config = { workspace = true }
+
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
 prometheus = "0.13.3"
+thiserror = "^1"
 reqwest = "0.11"
-axum = "0.6.4"
 hyper = "0.14.24"
 
 [features]

--- a/crates/tx-queue/Cargo.toml
+++ b/crates/tx-queue/Cargo.toml
@@ -1,25 +1,33 @@
 [package]
 name = "webb-relayer-tx-queue"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-relayer-types = { path = "../relayer-types" }
-webb-relayer-store = { path = "../relayer-store" }
-webb-relayer-context = { path = "../relayer-context"}
-webb-relayer-utils = { path = "../relayer-utils"}
-tracing = { version = "^0.1", features = ["log"] }
-sled = { version = "^0.34" }
-futures = { version = "^0.3", default-features = false }
-backoff = { version = "0.4.0", features = ["tokio"] }
-tokio = { version = "^1", features = ["full"] }
-rand = { version = "0.8", default-features = false, features = ["getrandom"] }
-webb = { version = "0.5.14", default-features = false }
+webb-relayer-types = { workspace = true }
+webb-relayer-store = { workspace = true }
+webb-relayer-context = { workspace = true }
+webb-relayer-utils = { workspace = true }
+
+tracing = { workspace = true }
+sled = { workspace = true }
+futures = { workspace = true }
+backoff = { workspace = true }
+tokio = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-ethereum-types = "0.14.1"
+native-tls = { workspace = true, optional = true }
+ethereum-types = { workspace = true }
+
+rand = { version = "0.8", default-features = false, features = ["getrandom"] }
+
 
 [features]
 default = ["std", "evm", "substrate"]

--- a/crates/tx-relay-utils/Cargo.toml
+++ b/crates/tx-relay-utils/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "webb-relayer-tx-relay-utils"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "^1", default-features = false, features = ["derive"] }
+serde = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
+native-tls = { workspace = true, optional = true }

--- a/crates/tx-relay/Cargo.toml
+++ b/crates/tx-relay/Cargo.toml
@@ -1,26 +1,33 @@
 [package]
 name = "webb-relayer-tx-relay"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-relayer-handler-utils = { path = "../relayer-handler-utils" }
-webb-relayer-config = { path = "../relayer-config"}
-webb-relayer-context = { path = "../relayer-context"}
-webb-relayer-utils = { path = "../relayer-utils"}
-tracing = { version = "^0.1", features = ["log"] }
-futures = { version = "^0.3", default-features = false }
-tokio = { version = "^1", features = ["full"] }
-webb = { version = "0.5.14", default-features = false }
+webb-relayer-handler-utils = { workspace = true }
+webb-relayer-config = { workspace = true }
+webb-relayer-context = { workspace = true }
+webb-relayer-utils = { workspace = true }
+
+tracing = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+ethereum-types = { workspace = true }
+serde = { workspace = true }
+
 once_cell = "1.17.0"
 chrono = {version = "0.4.23", features = ["serde"] }
-serde = { version = "^1", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std", "evm", "substrate"]

--- a/event-watchers/dkg/Cargo.toml
+++ b/event-watchers/dkg/Cargo.toml
@@ -1,22 +1,28 @@
 [package]
 name = "webb-ew-dkg"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-event-watcher-traits = { path = "../../crates/event-watcher-traits" }
-webb-relayer-store = { path = "../../crates/relayer-store" }
-webb-relayer-config = { path = "../../crates/relayer-config"}
-webb-relayer-utils = { path = "../../crates/relayer-utils"}
-async-trait = "^0.1"
-tracing = { version = "^0.1", features = ["log"] }
-sled = { version = "^0.34" }
-tokio = { version = "^1", features = ["full"] }
-hex = { version = "0.4", default-features = false }
-webb = { version = "0.5.14", default-features = false }
+webb-event-watcher-traits = { workspace = true }
+webb-relayer-store = { workspace = true }
+webb-relayer-config = { workspace = true }
+webb-relayer-utils = { workspace = true }
+
+async-trait = { workspace = true }
+tracing = { workspace = true }
+sled = { workspace = true }
+tokio = { workspace = true }
+hex = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+ethereum-types = { workspace = true }

--- a/event-watchers/evm/Cargo.toml
+++ b/event-watchers/evm/Cargo.toml
@@ -1,24 +1,30 @@
 [package]
 name = "webb-ew-evm"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-proposal-signing-backends = { path = "../../crates/proposal-signing-backends" }
-webb-event-watcher-traits = { path = "../../crates/event-watcher-traits" }
-webb-relayer-store = { path = "../../crates/relayer-store" }
-webb-relayer-config = { path = "../../crates/relayer-config"}
-webb-relayer-utils = { path = "../../crates/relayer-utils"}
-async-trait = "^0.1"
-tracing = { version = "^0.1", features = ["log"] }
-sled = { version = "^0.34" }
-tokio = { version = "^1", features = ["full"] }
-serde_json = { version = "^1", default-features = false }
-hex = { version = "0.4", default-features = false }
-webb = { version = "0.5.14", default-features = false }
+webb-proposal-signing-backends = { workspace = true }
+webb-event-watcher-traits = { workspace = true }
+webb-relayer-store = { workspace = true }
+webb-relayer-config = { workspace = true }
+webb-relayer-utils = { workspace = true }
+
+async-trait = { workspace = true }
+tracing = { workspace = true }
+sled = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+hex = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
+native-tls = { workspace = true }
+webb-proposals ={ workspace = true }
+ethereum-types = { workspace = true }

--- a/event-watchers/substrate/Cargo.toml
+++ b/event-watchers/substrate/Cargo.toml
@@ -1,24 +1,30 @@
 [package]
 name = "webb-ew-substrate"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-proposal-signing-backends = { path = "../../crates/proposal-signing-backends" }
-webb-event-watcher-traits = { path = "../../crates/event-watcher-traits" }
-webb-relayer-types = { path = "../../crates/relayer-types" }
-webb-relayer-store = { path = "../../crates/relayer-store" }
-webb-relayer-config = { path = "../../crates/relayer-config"}
-webb-relayer-utils = { path = "../../crates/relayer-utils"}
-async-trait = "^0.1"
-tracing = { version = "^0.1", features = ["log"] }
-sled = { version = "^0.34" }
-tokio = { version = "^1", features = ["full"] }
-hex = { version = "0.4", default-features = false }
-webb = { version = "0.5.14", default-features = false }
+webb-proposal-signing-backends = { workspace = true }
+webb-event-watcher-traits = { workspace = true }
+webb-relayer-types = { workspace = true }
+webb-relayer-store = { workspace = true }
+webb-relayer-config = { workspace = true }
+webb-relayer-utils = { workspace = true }
+
+async-trait = { workspace = true }
+tracing = { workspace = true }
+sled = { workspace = true }
+tokio = { workspace = true }
+hex = { workspace = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-libsecp256k1 = "0.7.1"
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+libsecp256k1 = { workspace = true }

--- a/services/block-poller/Cargo.toml
+++ b/services/block-poller/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "webb-block-poller"
 version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,28 +19,26 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-webb-relayer-store = { path = "../../crates/relayer-store" }
-webb-relayer-config = { path = "../../crates/relayer-config" }
-webb-relayer-context = { path = "../../crates/relayer-context" }
-webb-relayer-utils = { path = "../../crates/relayer-utils"}
-webb-relayer = { path = "../webb-relayer" }
+webb-relayer-store = { workspace = true }
+webb-relayer-config = { workspace = true }
+webb-relayer-context = { workspace = true }
+webb-relayer-utils = { workspace = true }
+webb-relayer = { workspace = true }
 
-anyhow = { version = "^1", optional = true }
-async-trait = "^0.1"
-tracing = { version = "^0.1", features = ["log"] }
-futures = { version = "^0.3", default-features = false }
-backoff = { version = "0.4.0", features = ["tokio"] }
-tokio = { version = "^1", features = ["full"] }
-serde_json = { version = "^1", default-features = false }
-paw = { version = "^1.0", optional = true }
-webb = { version = "0.5.14", default-features = false }
-# Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-ethereum-types = "0.14.1"
-dotenv = "0.15.0"
+anyhow = { workspace = true, optional = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+backoff = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+paw = { workspace = true, optional = true }
+webb = { workspace = true }
+ethereum-types = { workspace = true }
+dotenv = { workspace = true }
 
 [dev-dependencies]
-tempfile = "^3.3"
+tempfile = { workspace = true }
 
 [features]
 default = ["cli"]

--- a/services/webb-relayer/Cargo.toml
+++ b/services/webb-relayer/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "webb-relayer"
 version = "0.4.1"
-authors = ["Webb Developers <drew@webb.tools>"]
-edition = "2021"
 description = "The Webb Relayer toolkit"
-license = "Apache-2.0"
-documentation = "https://docs.rs/webb-relayer"
-homepage = "https://webb.tools"
-repository = "https://github.com/webb-tools/relayer"
 exclude = ["tests", "config", ".github", "ci", "assets", "docker"]
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 [lib]
 doctest = false
@@ -24,37 +24,38 @@ path = "../../examples/in_depth.rs"
 required-features = ["cli"]
 
 [dependencies]
-webb-proposal-signing-backends = { path = "../../crates/proposal-signing-backends" }
-webb-relayer-tx-queue = { path = "../../crates/tx-queue" }
-webb-relayer-handlers = { path = "../../crates/relayer-handlers" }
-webb-relayer-store = { path = "../../crates/relayer-store" }
-webb-relayer-config = { path = "../../crates/relayer-config" }
-webb-relayer-context = { path = "../../crates/relayer-context" }
-webb-relayer-utils = { path = "../../crates/relayer-utils"}
-webb-event-watcher-traits = { path = "../../crates/event-watcher-traits"}
-webb-ew-dkg = { path = "../../event-watchers/dkg" }
-webb-ew-evm = { path = "../../event-watchers/evm" }
-webb-ew-substrate = { path = "../../event-watchers/substrate" }
+webb-proposal-signing-backends = { workspace = true }
+webb-relayer-tx-queue = { workspace = true }
+webb-relayer-handlers = { workspace = true }
+webb-relayer-store = { workspace = true }
+webb-relayer-config = { workspace = true }
+webb-relayer-context = { workspace = true }
+webb-relayer-utils = { workspace = true }
+webb-event-watcher-traits = { workspace = true }
+webb-ew-dkg = { workspace = true }
+webb-ew-evm = { workspace = true }
+webb-ew-substrate = { workspace = true }
 
-anyhow = { version = "^1", optional = true }
-tracing = { version = "^0.1", features = ["log"] }
-url = { version = "^2.3", features = ["serde"] }
-sled = { version = "^0.34" }
-tokio = { version = "^1", features = ["full"] }
-config = { version = "0.13", default-features = false, features = ["toml", "json"] }
-serde_json = { version = "^1", default-features = false }
-paw = { version = "^1.0", optional = true }
-webb = { version = "0.5.14", default-features = false }
+anyhow = { workspace = true, optional = true }
+tracing = { workspace = true }
+url = { workspace = true }
+sled = { workspace = true }
+tokio = { workspace = true }
+config = { workspace = true }
+serde_json = { workspace = true }
+paw = { workspace = true, optional = true }
+webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
-native-tls = { version = "^0.2", features = ["vendored"], optional = true }
-webb-proposals = { version = "0.5.4", default-features = false, features = ["scale"] }
-ethereum-types = "0.14.1"
-dotenv = "0.15.0"
-axum = { version = "0.6.4", features = ["ws"] }
+native-tls = { workspace = true, optional = true }
+webb-proposals = { workspace = true }
+ethereum-types = { workspace = true }
+dotenv = { workspace = true }
+axum = { workspace = true }
+
 tower-http = { version = "0.3.5", features = ["cors", "trace"] }
 
 [dev-dependencies]
-tempfile = "^3.3"
+tempfile = { workspace = true }
 
 [features]
 default = ["evm-runtime", "substrate-runtime"]


### PR DESCRIPTION
## Summary of changes
- Use workspace inheritance to specify dependencies and crate metadata only one. I only extracted deps which are used by two or more crates. Regarding crate versions I wasnt sure if its intentional that they differ. If all crates should have the same version then this should also be specified in the root `Cargo.toml`.

By the way, in my opinion this project is split into too many crates. I dont think there is any benefit to having crates with only a single file.

### Reference issue to close (if applicable)
- Closes #348

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
