### PR TITLE
Dont run apt-get upgrade in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,7 +90,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: install system build dependencies
-        run: sudo apt-get update && sudo apt-get upgrade && sudo apt-get install ${DEV_PACKAGES}
+        run: sudo apt-get update && sudo apt-get install ${DEV_PACKAGES}
 
       - uses: actions/checkout@v3
         with:
@@ -127,7 +127,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: install system build dependencies
-        run: sudo apt-get update && sudo apt-get upgrade && sudo apt-get install ${DEV_PACKAGES}
+        run: sudo apt-get update && sudo apt-get install ${DEV_PACKAGES}
 
       - uses: actions/checkout@v3
         with:
@@ -181,7 +181,7 @@ jobs:
           access_token: ${{ github.token }}
           
       - name: install system build dependencies
-        run: sudo apt-get update && sudo apt-get upgrade && sudo apt-get install ${DEV_PACKAGES}
+        run: sudo apt-get update && sudo apt-get install ${DEV_PACKAGES}
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary of changes
- Dont run `apt-get upgrade` in CI. Its not necessary and can only cause problems.


### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
