### PR TITLE
[feat] Introduce Price Oracle Backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "base64 0.21.0",
  "bitflags",
  "bytes 1.4.0",
@@ -564,6 +565,18 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb524613be645939e280b7279f7b017f98cf7f5ef084ec374df373530e73277"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1079,19 +1092,6 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
-]
-
-[[package]]
-name = "coingecko"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24c2d346c689c0b8a27d4c921a35d8cac68cc266130bc82ba879155ca828da0"
-dependencies = [
- "chrono",
- "reqwest",
- "serde",
- "serde_json",
- "tokio 1.27.0",
 ]
 
 [[package]]
@@ -8128,11 +8128,13 @@ name = "webb-price-oracle-backends"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
- "coingecko",
  "futures",
  "native-tls",
+ "reqwest",
  "serde",
+ "tokio 1.27.0",
  "typed-builder 0.12.0",
  "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-relayer-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "ark-bls12-381"
@@ -406,9 +406,9 @@ checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -421,6 +421,15 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "async-lock"
@@ -445,7 +454,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -508,7 +517,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body 0.4.5",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "itoa 1.0.6",
  "matchit",
  "memchr",
@@ -522,7 +531,7 @@ dependencies = [
  "serde_urlencoded 0.7.1",
  "sha1",
  "sync_wrapper",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-tungstenite 0.18.0",
  "tower",
  "tower-layer",
@@ -568,7 +577,7 @@ dependencies = [
  "instant",
  "pin-project-lite 0.2.9",
  "rand 0.8.5",
- "tokio 1.26.0",
+ "tokio 1.27.0",
 ]
 
 [[package]]
@@ -593,26 +602,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base58"
-version = "0.1.0"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
-name = "base58check"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee2fe4c9a0c84515f136aaae2466744a721af6d63339c18689d9e995d74d99b"
-dependencies = [
- "base58 0.1.0",
- "sha2 0.8.2",
-]
 
 [[package]]
 name = "base64"
@@ -634,9 +633,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.0.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
@@ -661,6 +660,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -728,7 +742,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -737,7 +751,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -770,7 +784,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "eth2_hashing 0.3.0 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
  "eth2_serde_utils 0.1.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
@@ -860,6 +874,9 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2 0.9.9",
+]
 
 [[package]]
 name = "buf_redux"
@@ -944,13 +961,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "thiserror",
@@ -976,9 +993,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1074,14 +1091,14 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio 1.26.0",
+ "tokio 1.27.0",
 ]
 
 [[package]]
 name = "coins-bip32"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c509653de24b439672164bbf56f5f582a2ab0e313d3b0f6af0b7345cf2560"
+checksum = "b30a84aab436fcb256a2ab3c80663d8aec686e6bae12827bb05fef3e1e439c9f"
 dependencies = [
  "bincode",
  "bs58",
@@ -1089,7 +1106,7 @@ dependencies = [
  "digest 0.10.6",
  "getrandom 0.2.8",
  "hmac 0.12.1",
- "k256",
+ "k256 0.13.0",
  "lazy_static",
  "serde",
  "sha2 0.10.6",
@@ -1098,33 +1115,34 @@ dependencies = [
 
 [[package]]
 name = "coins-bip39"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a11892bcac83b4c6e95ab84b5b06c76d9d70ad73548dd07418269c5c7977171"
+checksum = "efb68f3b6c3fee83828ecd8d463f360a397c32aaeb35bd931c01e5ddf5631c69"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
  "getrandom 0.2.8",
  "hex",
  "hmac 0.12.1",
- "pbkdf2 0.11.0",
+ "once_cell",
+ "pbkdf2 0.12.1",
  "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "coins-core"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94090a6663f224feae66ab01e41a2555a8296ee07b5f20dab8888bdefc9f617"
+checksum = "9b949a1c63fb7eb591eb7ba438746326aedf0ae843e51ec92ba6bec5bb382c4f"
 dependencies = [
- "base58check",
- "base64 0.12.3",
+ "base64 0.21.0",
  "bech32",
- "blake2 0.10.6",
+ "bs58",
  "digest 0.10.6",
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "hex",
  "ripemd",
  "serde",
@@ -1171,13 +1189,13 @@ dependencies = [
  "pathdiff",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
 name = "consensus_types"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "bitvec 1.0.1",
  "derive_more",
@@ -1227,37 +1245,37 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8263ce52392898aa17c2a0984b7c542df416e434f6e0cb1c1a11771054d159"
+checksum = "f22add0f9b2a5416df98c1d0248a8d8eedb882c38fbf0c5052b64eebe865df6d"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
- "k256",
+ "k256 0.11.6",
  "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1895f6d7a191bb044e3c555190d1da555c2571a3af41f849f60c855580e392f"
+checksum = "c2e64f710a18ef90d0a632cf27842e98ffc2d005a38a6f76c12fd0bc03bc1a2d"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc01051aab3bb88d5efe0b90f24a6df1ca96a873b12fc21b862b17539c84ee9"
+checksum = "76fee88ff5bf7bef55bd37ac0619974701b99bf6bd4b16cf56ee8810718abd71"
 dependencies = [
  "base64 0.13.1",
  "cosmwasm-crypto",
@@ -1284,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1364,7 +1382,19 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+dependencies = [
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -1376,7 +1406,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -1386,7 +1416,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -1396,7 +1426,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -1437,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1449,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1459,24 +1489,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1560,6 +1590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,7 +1644,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1617,6 +1663,16 @@ name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
@@ -1690,10 +1746,22 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
+dependencies = [
+ "der 0.7.1",
+ "elliptic-curve 0.13.2",
+ "rfc6979 0.4.0",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -1702,7 +1770,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1744,18 +1812,46 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.6",
- "ff",
- "generic-array 0.14.6",
- "group",
- "pkcs8",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.1",
+ "digest 0.10.6",
+ "ff 0.13.0",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "pkcs8 0.10.1",
+ "rand_core 0.6.4",
+ "sec1 0.7.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1769,15 +1865,14 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a7e5fc2504d5fdce8e124d3e263b244a68b283cac67a69eda0cd43e0aebad"
+checksum = "eb4d5fbf6f56acecd38f5988eb2e4ae412008a2a30268c748c701ec6322f39d4"
 dependencies = [
  "base64 0.13.1",
- "bs58",
  "bytes 1.4.0",
  "hex",
- "k256",
+ "k256 0.13.0",
  "log",
  "rand 0.8.5",
  "rlp",
@@ -1807,13 +1902,13 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi 0.3.9",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1851,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "derive_more",
  "eth2_serde_utils 0.1.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
@@ -1871,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "eth2-pallet-init"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "async-trait",
  "clap 3.2.23",
@@ -1889,10 +1984,10 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "subxt",
- "tokio 1.26.0",
- "toml",
+ "tokio 1.27.0",
+ "toml 0.5.11",
  "tree_hash 0.4.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-types 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
  "webb-relayer-utils 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
@@ -1912,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "eth2_hashing"
 version = "0.3.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "lazy_static",
  "ring",
@@ -1949,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "eth2_serde_utils"
 version = "0.1.1"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "ethereum-types 0.14.1",
  "hex",
@@ -1970,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "eth2_ssz"
 version = "0.4.1"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "ethereum-types 0.14.1",
  "itertools",
@@ -2006,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "eth2_to_substrate_relay"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2034,12 +2129,12 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "thread",
- "tokio 1.26.0",
- "toml",
+ "tokio 1.27.0",
+ "toml 0.5.11",
  "tree_hash 0.4.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
  "types",
  "warp",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-utils 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
 ]
@@ -2047,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "eth_rpc_client"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "async-std",
  "atomic_refcell",
@@ -2072,8 +2167,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thread",
- "tokio 1.26.0",
- "toml",
+ "tokio 1.27.0",
+ "toml 0.5.11",
  "tree_hash 0.4.1 (git+https://github.com/webb-tools/lighthouse.git?branch=develop)",
  "types",
  "warp",
@@ -2156,26 +2251,53 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839a392641e746a1ff365ef7c901238410b5c6285d240cf2409ffaaa7df9a78a"
+checksum = "697aba1bec98cb86e7bebd69f9bb365218871464137af9e93e7a72bd6dc421d0"
 dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
+ "ethers-addressbook 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-etherscan 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-middleware 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-solc 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "ethers-addressbook 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
 ]
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1e010165c08a2a3fa43c0bb8bc9d596f079a021aaa2cc4e8d921df09709c95"
+checksum = "c0b603812e5e4d63521c691cbc1f34743879e96a1ee96c6594639d7fa0cf6fbc"
 dependencies = [
- "ethers-core",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "once_cell",
  "serde",
  "serde_json",
@@ -2183,14 +2305,32 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be33fd47a06cc8f97caf614cf7cf91af9dd6dcd767511578895fa884b430c4b8"
+checksum = "b4e8ed7c2b2a22e07b65ae0eb426c948a7448f1be15c66e4813e02c423751fc9"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
+ "ethers-contract-abigen 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract-derive 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project 1.0.12",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "ethers-contract-abigen 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-derive 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "futures-util",
  "hex",
  "once_cell",
@@ -2202,15 +2342,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d9f9ecb4a18c1693de954404b66e0c9df31dac055b411645e38c4efebf3dbc"
+checksum = "bf0984f4ec4e267fd27b7c9fa2f73e72c5c98491a73f777290654154d104f723"
 dependencies = [
  "Inflector",
- "cfg-if 1.0.0",
  "dunce",
- "ethers-core",
- "ethers-etherscan",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-etherscan 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "eyre",
  "getrandom 0.2.8",
  "hex",
@@ -2222,52 +2361,120 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 1.0.109",
- "tokio 1.26.0",
- "toml",
+ "tokio 1.27.0",
+ "toml 0.7.3",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "Inflector",
+ "dunce",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "getrandom 0.2.8",
+ "hex",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tokio 1.27.0",
+ "toml 0.7.3",
  "url",
  "walkdir",
 ]
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001b33443a67e273120923df18bab907a0744ad4b5fef681a8b0691f2ee0f3de"
+checksum = "914e9211077a1b590af1ee6b8dfbd54515c808119546c95da69479908dc3d4de"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-core",
- "eyre",
+ "ethers-contract-abigen 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "proc-macro2",
  "quote",
- "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "ethers-contract-abigen 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "hex",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "ethers-core"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5925cba515ac18eb5c798ddf6069cc33ae00916cb08ae64194364a1b35c100b"
+checksum = "40bf114f1017ace0f622f1652f59c2c5e1abfe7d88891cca0c43da979b351de0"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.4.0",
  "cargo_metadata",
  "chrono",
  "convert_case 0.6.0",
- "elliptic-curve",
+ "elliptic-curve 0.13.2",
  "ethabi",
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "getrandom 0.2.8",
  "hex",
- "k256",
+ "k256 0.13.0",
  "num_enum",
  "once_cell",
  "open-fastrlp",
  "proc-macro2",
  "rand 0.8.5",
  "rlp",
- "rlp-derive",
+ "serde",
+ "serde_json",
+ "strum",
+ "syn 1.0.109",
+ "tempfile",
+ "thiserror",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-core"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bytes 1.4.0",
+ "cargo_metadata",
+ "chrono",
+ "convert_case 0.6.0",
+ "elliptic-curve 0.13.2",
+ "ethabi",
+ "generic-array 0.14.7",
+ "getrandom 0.2.8",
+ "hex",
+ "k256 0.13.0",
+ "num_enum",
+ "once_cell",
+ "open-fastrlp",
+ "proc-macro2",
+ "rand 0.8.5",
+ "rlp",
  "serde",
  "serde_json",
  "strum",
@@ -2280,16 +2487,32 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d769437fafd0b47ea8b95e774e343c5195c77423f0f54b48d11c0d9ed2148ad"
+checksum = "8920b59cf81e357df2c8102d6a9dc81c2d68f7409543ff3b6868851ecf007807"
 dependencies = [
- "ethers-core",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-solc 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.2.8",
  "reqwest",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
- "serde-aux",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "getrandom 0.2.8",
+ "reqwest",
+ "semver 1.0.17",
+ "serde",
  "serde_json",
  "thiserror",
  "tracing",
@@ -2297,17 +2520,18 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dd311b76eab9d15209e4fd16bb419e25543709cbdf33079e8923dfa597517c"
+checksum = "c54b30f67c1883ed68bd38aedbdd321831382c12e1b95089c8261c79bb85e4da"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
+ "ethers-contract 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-etherscan 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
  "futures-locks",
  "futures-util",
  "instant",
@@ -2315,7 +2539,33 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 1.26.0",
+ "tokio 1.27.0",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio 1.27.0",
  "tracing",
  "tracing-futures",
  "url",
@@ -2323,15 +2573,16 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7174af93619e81844d3d49887106a3721e5caecdf306e0b824bfb4316db3be"
+checksum = "c2fa0857eaad0c1678f982a2f4cfbe33ebd51d273cc93de0182b7c693f2a84a1"
 dependencies = [
  "async-trait",
  "auto_impl",
  "base64 0.21.0",
+ "bytes 1.4.0",
  "enr",
- "ethers-core",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -2339,41 +2590,154 @@ dependencies = [
  "hashers",
  "hex",
  "http",
+ "instant",
  "once_cell",
- "parking_lot 0.11.2",
  "pin-project 1.0.12",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
  "tracing-futures",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-timer",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.0",
+ "bytes 1.4.0",
+ "enr",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.2.8",
+ "hashers",
+ "hex",
+ "http",
+ "instant",
+ "once_cell",
+ "pin-project 1.0.12",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio 1.27.0",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d45ff294473124fd5bb96be56516ace179eef0eaec5b281f68c953ddea1a8bf"
+checksum = "5caa7cad4f444931d0ed45818e609847781582399eff0be5c089e8666475c7fb"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve",
+ "elliptic-curve 0.13.2",
  "eth-keystore",
- "ethers-core",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "elliptic-curve 0.13.2",
+ "eth-keystore",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "hex",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139542f51f4c405d0dd7e97c34232140a14e8744d1cf121777355567187259e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dunce",
+ "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.2.8",
+ "glob",
+ "hex",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.17",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "thiserror",
+ "tiny-keccak",
+ "tokio 1.27.0",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.2"
+source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dunce",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "getrandom 0.2.8",
+ "glob",
+ "hex",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.17",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "thiserror",
+ "tiny-keccak",
+ "tokio 1.27.0",
+ "tracing",
+ "walkdir",
+ "yansi",
 ]
 
 [[package]]
@@ -2430,9 +2794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "finality-update-verify"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "bitvec 1.0.1",
  "bls 0.2.0 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
@@ -2465,6 +2839,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -2514,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6bb8542ef006ef0de09a5c4420787d79823c0ed7924225822362fd2bf2ff2d"
+checksum = "878babb0b136e731cc77ec2fd883ff02745ff21e6fb662729953d44923df009c"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
@@ -2558,9 +2938,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2573,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2583,15 +2963,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2601,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-locks"
@@ -2617,38 +2997,42 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2682,12 +3066,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2737,12 +3122,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2781,7 +3189,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-util 0.7.7",
  "tracing",
 ]
@@ -2902,6 +3310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,8 +3363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3041,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes 1.4.0",
  "futures-channel",
@@ -3057,7 +3480,7 @@ dependencies = [
  "itoa 1.0.6",
  "pin-project-lite 0.2.9",
  "socket2 0.4.9",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tower-service",
  "tracing",
  "want",
@@ -3070,11 +3493,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-rustls",
  "webpki-roots",
 ]
@@ -3086,24 +3509,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.4.0",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "native-tls",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-native-tls",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows",
 ]
 
 [[package]]
@@ -3187,9 +3610,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -3202,7 +3625,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -3221,9 +3644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3245,10 +3665,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -3264,9 +3685,21 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix 0.37.7",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "itertools"
@@ -3324,7 +3757,7 @@ dependencies = [
  "rustls-native-certs",
  "soketto",
  "thiserror",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-rustls",
  "tokio-util 0.7.7",
  "tracing",
@@ -3344,13 +3777,13 @@ dependencies = [
  "futures-channel",
  "futures-timer",
  "futures-util",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "jsonrpsee-types",
  "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
 ]
 
@@ -3361,7 +3794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
 dependencies = [
  "async-trait",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3369,7 +3802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
 ]
 
@@ -3394,10 +3827,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if 1.0.0",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.6",
- "sha3",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955890845095ccf31ef83ad41a05aabb4d8cc23dc3cac5a9f5c89cf26dd0da75"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa 0.16.2",
+ "elliptic-curve 0.13.2",
+ "once_cell",
+ "sha2 0.10.6",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -3420,6 +3866,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34313ec00c2eb5c3c87ca6732ea02dcf3af99c3ff7a8fb622ffb99c9d860a87"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c1f7869c94d214466c5fd432dfed12c379fd87786768d36455892d46b18edd"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libflate"
@@ -3541,6 +4019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,6 +4084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,11 +4100,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix",
+ "rustix 0.37.7",
 ]
 
 [[package]]
@@ -3662,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "eth2_hashing 0.3.0 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
  "ethereum-types 0.14.1",
@@ -3696,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -3814,6 +4307,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nohash-hasher"
@@ -3996,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -4011,13 +4510,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4028,20 +4527,19 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.1+1.1.1t"
+version = "111.25.2+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef9a9cc6ea7d9d5e7c4a913dc4b48d0e359eddf01af1dfec96ba7064b4aba10"
+checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -4051,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "overload"
@@ -4124,7 +4622,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -4137,20 +4635,9 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -4158,6 +4645,12 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pathdiff"
@@ -4208,9 +4701,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.6",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
+dependencies = [
+ "digest 0.10.6",
  "hmac 0.12.1",
- "password-hash",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -4221,12 +4721,22 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -4238,6 +4748,63 @@ dependencies = [
  "futures",
  "rustc_version 0.4.0",
 ]
+
+[[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared 0.11.1",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -4303,8 +4870,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der 0.7.1",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -4320,10 +4897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.1.24"
+name = "precomputed-hash"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -4362,7 +4945,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -4401,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -4607,41 +5190,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.8",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9af2cf09ef80e610097515e80095b7f76660a92743c4185aff5406cd5ce3dd5"
+checksum = "f43faa91b1c8b36841ee70e97188a869d37ae21759da6846d4be66de5bf7b12c"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c501201393982e275433bc55de7d6ae6f00e7699cd5572c5b57581cd69c881b"
+checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4659,15 +5251,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes 1.4.0",
@@ -4677,8 +5269,7 @@ dependencies = [
  "h2 0.3.16",
  "http",
  "http-body 0.4.5",
- "hyper 0.14.24",
- "hyper-rustls",
+ "hyper 0.14.25",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -4688,20 +5279,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.9",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-native-tls",
- "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -4711,9 +5298,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4753,6 +5350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes 1.4.0",
+ "rlp-derive",
  "rustc-hex",
 ]
 
@@ -4784,9 +5382,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc-hash"
@@ -4815,20 +5413,34 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "e0af200a3324fa5bcd922e84e9b55a298ea9f431a489f01961acdebc6e908f25"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.1",
  "windows-sys 0.45.0",
 ]
 
@@ -4885,7 +5497,7 @@ source = "git+https://github.com/webb-tools/lighthouse.git?branch=develop#913b28
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 
 [[package]]
 name = "safemem"
@@ -4936,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
+checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
 dependencies = [
  "bitvec 1.0.1",
  "cfg-if 1.0.0",
@@ -4950,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
+checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -5085,10 +5697,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
- "generic-array 0.14.6",
- "pkcs8",
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -5154,9 +5780,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -5172,27 +5798,23 @@ dependencies = [
 
 [[package]]
 name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-aux"
-version = "4.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c599b3fd89a75e0c18d6d2be693ddb12cccaf771db4ff9e39097104808a014c0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5206,13 +5828,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -5228,9 +5850,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -5239,9 +5861,18 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0969fff533976baadd92e08b1d102c5a3d8a8049eadfd69d4d1e3c5b2ed189"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
 dependencies = [
  "serde",
 ]
@@ -5403,6 +6034,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5476,6 +6123,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solang-parser"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff87dae6cdccacdbf3b19e99b271083556e808de0f59c74a01482f64fdbc61fc"
+dependencies = [
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "phf",
+ "unicode-xid",
+]
+
+[[package]]
 name = "sp-application-crypto"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5511,7 +6171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c96dc3debbe5c22ebf18f99e6a53199efe748e6e584a1902adb88cbad66ae7c"
 dependencies = [
  "array-bytes",
- "base58 0.2.0",
+ "base58",
  "bitflags",
  "blake2 0.10.6",
  "bounded-collections",
@@ -5829,7 +6489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.1",
 ]
 
 [[package]]
@@ -5858,6 +6528,19 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -5943,7 +6626,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54639dba6a113584083968b6a8f457dedae612abe1bd214762101ca29f12e332"
 dependencies = [
- "base58 0.2.0",
+ "base58",
  "blake2 0.10.6",
  "derivative",
  "frame-metadata",
@@ -5988,7 +6671,7 @@ dependencies = [
  "scale-info",
  "subxt-metadata",
  "syn 1.0.109",
- "tokio 1.26.0",
+ "tokio 1.27.0",
 ]
 
 [[package]]
@@ -6051,9 +6734,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6065,18 +6748,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
 
 [[package]]
 name = "tap"
@@ -6092,15 +6763,26 @@ checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.7",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6138,22 +6820,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -6254,14 +6936,13 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
  "libc",
- "memchr",
  "mio 0.8.6",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -6274,13 +6955,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -6290,7 +6971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio 1.26.0",
+ "tokio 1.27.0",
 ]
 
 [[package]]
@@ -6300,7 +6981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "webpki",
 ]
 
@@ -6312,7 +6993,7 @@ checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
- "tokio 1.26.0",
+ "tokio 1.27.0",
 ]
 
 [[package]]
@@ -6336,7 +7017,7 @@ checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tungstenite 0.18.0",
 ]
 
@@ -6365,7 +7046,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "pin-project-lite 0.2.9",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
 ]
 
@@ -6379,18 +7060,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -6405,7 +7103,7 @@ dependencies = [
  "futures-util",
  "pin-project 1.0.12",
  "pin-project-lite 0.2.9",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6587,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "tree_hash"
 version = "0.4.1"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "eth2_hashing 0.3.0 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
  "ethereum-types 0.14.1",
@@ -6607,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "tree_hash_derive"
 version = "0.4.0"
-source = "git+https://github.com/webb-tools/pallet-eth2-light-client#85a6561d61e5cbab074c266dccd9e9ed687f1321"
+source = "git+https://github.com/webb-tools/pallet-eth2-light-client#e08be1f4fb6a0dd1ac1068eca7b0e3d88e16d5da"
 dependencies = [
  "darling 0.13.4",
  "quote",
@@ -6803,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -6906,12 +7604,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -7036,21 +7733,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wasmi"
@@ -7208,7 +7890,7 @@ dependencies = [
  "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.36.12",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -7239,27 +7921,12 @@ dependencies = [
 
 [[package]]
 name = "webb"
-version = "0.5.19"
-source = "git+https://github.com/webb-tools/webb-rs#734dd92eb0a8b867058d97c911b4c8bacc522962"
-dependencies = [
- "async-trait",
- "ethers",
- "hex",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "webb"
 version = "0.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "426649fd51964143b49326891ba1d5a10f166645f7b5a16794a0045e8361ad27"
 dependencies = [
  "async-trait",
- "ethers",
+ "ethers 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -7267,6 +7934,21 @@ dependencies = [
  "serde",
  "serde_json",
  "subxt",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "webb"
+version = "0.5.21"
+source = "git+https://github.com/webb-tools/webb-rs#1ed2db6eaf930f94774af0293ac751707af825b0"
+dependencies = [
+ "async-trait",
+ "ethers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
 ]
@@ -7284,9 +7966,9 @@ dependencies = [
  "paw",
  "serde_json",
  "tempfile",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-relayer",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -7305,9 +7987,9 @@ dependencies = [
  "hex-literal",
  "native-tls",
  "sp-core",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "typed-builder 0.12.0",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-utils 0.1.0",
@@ -7322,10 +8004,10 @@ dependencies = [
  "futures",
  "native-tls",
  "sled",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
  "tracing-test",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -7342,9 +8024,9 @@ dependencies = [
  "hex",
  "native-tls",
  "sled",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-event-watcher-traits",
  "webb-proposals",
  "webb-relayer-config",
@@ -7369,9 +8051,9 @@ dependencies = [
  "native-tls",
  "serde_json",
  "sled",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-bridge-registry-backends",
  "webb-event-watcher-traits",
  "webb-proposal-signing-backends",
@@ -7391,9 +8073,9 @@ dependencies = [
  "native-tls",
  "sled",
  "sp-core",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-event-watcher-traits",
  "webb-proposal-signing-backends",
  "webb-proposals",
@@ -7424,9 +8106,9 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.19",
+ "webb 0.5.21 (git+https://github.com/webb-tools/webb-rs)",
  "webb-proposal-signing-backends",
  "webb-proposals",
  "webb-relayer",
@@ -7452,7 +8134,7 @@ dependencies = [
  "native-tls",
  "serde",
  "typed-builder 0.12.0",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-relayer-store",
  "webb-relayer-utils 0.1.0",
 ]
@@ -7468,10 +8150,10 @@ dependencies = [
  "native-tls",
  "sled",
  "sp-core",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
  "typed-builder 0.12.0",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-store",
  "webb-relayer-types 0.1.0",
@@ -7510,11 +8192,11 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "tempfile",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tower-http",
  "tracing",
  "url",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-bridge-registry-backends",
  "webb-event-watcher-traits",
  "webb-ew-dkg",
@@ -7550,7 +8232,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.16",
  "url",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-store",
  "webb-relayer-types 0.1.0",
@@ -7563,8 +8245,8 @@ version = "0.1.0"
 dependencies = [
  "native-tls",
  "sp-core",
- "tokio 1.26.0",
- "webb 0.5.21",
+ "tokio 1.27.0",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-price-oracle-backends",
  "webb-relayer-config",
  "webb-relayer-store",
@@ -7577,8 +8259,8 @@ version = "0.1.0"
 dependencies = [
  "native-tls",
  "serde",
- "tokio 1.26.0",
- "webb 0.5.21",
+ "tokio 1.27.0",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-relayer-tx-relay-utils",
 ]
 
@@ -7594,10 +8276,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tokio-stream",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -7619,7 +8301,7 @@ dependencies = [
  "sled",
  "tempfile",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-utils 0.1.0",
 ]
@@ -7636,9 +8318,9 @@ dependencies = [
  "sled",
  "sp-core",
  "sp-runtime",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-relayer-context",
  "webb-relayer-store",
  "webb-relayer-types 0.1.0",
@@ -7655,9 +8337,9 @@ dependencies = [
  "native-tls",
  "once_cell",
  "serde",
- "tokio 1.26.0",
+ "tokio 1.27.0",
  "tracing",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -7684,7 +8366,7 @@ dependencies = [
  "tiny-bip39",
  "tracing",
  "url",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7699,7 +8381,7 @@ dependencies = [
  "tiny-bip39",
  "tracing",
  "url",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7713,7 +8395,7 @@ dependencies = [
  "derive_more",
  "glob",
  "hex",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "libsecp256k1",
  "native-tls",
  "prometheus 0.13.3",
@@ -7723,7 +8405,7 @@ dependencies = [
  "sled",
  "thiserror",
  "url",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
 ]
 
@@ -7739,7 +8421,7 @@ dependencies = [
  "derive_more",
  "glob",
  "hex",
- "hyper 0.14.24",
+ "hyper 0.14.25",
  "libsecp256k1",
  "prometheus 0.13.3",
  "reqwest",
@@ -7748,7 +8430,7 @@ dependencies = [
  "sled",
  "thiserror",
  "url",
- "webb 0.5.21",
+ "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "webb-proposals",
 ]
 
@@ -7826,18 +8508,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7846,71 +8537,128 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -7946,7 +8694,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.0",
- "send_wrapper",
+ "send_wrapper 0.6.0",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7972,6 +8720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
 name = "yap"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7979,21 +8733,20 @@ checksum = "5fc77f52dc9e9b10d55d3f4462c3b7fc393c4f17975d641542833ab2d3bc26ef"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.13",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,24 +44,12 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher 0.3.0",
- "cpufeatures",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -435,15 +423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-lock"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,18 +474,6 @@ dependencies = [
  "hermit-abi 0.1.19",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "auto_impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -694,21 +661,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -959,27 +911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cached_tree_hash"
 version = "0.1.0"
 source = "git+https://github.com/webb-tools/lighthouse.git?branch=develop#913b28fb46ad651d3b6ca1efbfc85b68c3d314e3"
@@ -1030,9 +961,6 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -1057,18 +985,9 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
+ "time",
  "wasm-bindgen",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1276,43 +1195,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "unicode-width",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "console"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -1520,7 +1406,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1698,24 +1584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
-dependencies = [
- "console 0.14.1",
- "lazy_static",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,16 +1617,6 @@ name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if 1.0.0",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
@@ -1901,21 +1759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e5d13ca2353ab7d0230988629def93914a8c4015f621f9b13ed2955614731d"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,7 +1832,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
- "aes 0.8.2",
+ "aes",
  "ctr",
  "digest 0.10.6",
  "hex",
@@ -2313,45 +2156,17 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f26f9d8d80da18ca72aca51804c65eb2153093af3bec74fd5ce32aa0c1f665"
-dependencies = [
- "ethers-addressbook 1.0.2",
- "ethers-contract 1.0.2",
- "ethers-core 1.0.2",
- "ethers-etherscan 1.0.2",
- "ethers-middleware 1.0.2",
- "ethers-providers 1.0.2",
- "ethers-signers 1.0.2",
- "ethers-solc",
-]
-
-[[package]]
-name = "ethers"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "839a392641e746a1ff365ef7c901238410b5c6285d240cf2409ffaaa7df9a78a"
 dependencies = [
- "ethers-addressbook 2.0.0",
- "ethers-contract 2.0.0",
- "ethers-core 2.0.0",
- "ethers-etherscan 2.0.0",
- "ethers-middleware 2.0.0",
- "ethers-providers 2.0.0",
- "ethers-signers 2.0.0",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4be54dd2260945d784e06ccdeb5ad573e8f1541838cee13a1ab885485eaa0b"
-dependencies = [
- "ethers-core 1.0.2",
- "once_cell",
- "serde",
- "serde_json",
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
 ]
 
 [[package]]
@@ -2360,29 +2175,10 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1e010165c08a2a3fa43c0bb8bc9d596f079a021aaa2cc4e8d921df09709c95"
 dependencies = [
- "ethers-core 2.0.0",
+ "ethers-core",
  "once_cell",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c3c3e119a89f0a9a1e539e7faecea815f74ddcf7c90d0b00d1f524db2fdc9c"
-dependencies = [
- "ethers-contract-abigen 1.0.2",
- "ethers-contract-derive 1.0.2",
- "ethers-core 1.0.2",
- "ethers-providers 1.0.2",
- "futures-util",
- "hex",
- "once_cell",
- "pin-project 1.0.12",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -2391,10 +2187,10 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be33fd47a06cc8f97caf614cf7cf91af9dd6dcd767511578895fa884b430c4b8"
 dependencies = [
- "ethers-contract-abigen 2.0.0",
- "ethers-contract-derive 2.0.0",
- "ethers-core 2.0.0",
- "ethers-providers 2.0.0",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
  "futures-util",
  "hex",
  "once_cell",
@@ -2402,31 +2198,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4e5ad46aede34901f71afdb7bb555710ed9613d88d644245c657dc371aa228"
-dependencies = [
- "Inflector",
- "cfg-if 1.0.0",
- "dunce",
- "ethers-core 1.0.2",
- "eyre",
- "getrandom 0.2.8",
- "hex",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "syn 1.0.109",
- "toml",
- "url",
- "walkdir",
 ]
 
 [[package]]
@@ -2438,8 +2209,8 @@ dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
  "dunce",
- "ethers-core 2.0.0",
- "ethers-etherscan 2.0.0",
+ "ethers-core",
+ "ethers-etherscan",
  "eyre",
  "getrandom 0.2.8",
  "hex",
@@ -2459,64 +2230,18 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f192e8e4cf2b038318aae01e94e7644e0659a76219e94bcd3203df744341d61f"
-dependencies = [
- "ethers-contract-abigen 1.0.2",
- "ethers-core 1.0.2",
- "hex",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ethers-contract-derive"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "001b33443a67e273120923df18bab907a0744ad4b5fef681a8b0691f2ee0f3de"
 dependencies = [
- "ethers-contract-abigen 2.0.0",
- "ethers-core 2.0.0",
+ "ethers-contract-abigen",
+ "ethers-core",
  "eyre",
  "hex",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ethers-core"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3e9c97727343984e1ceada4fdab11142d2ee3472d2c67027d56b1251d4f15"
-dependencies = [
- "arrayvec 0.7.2",
- "bytes 1.4.0",
- "cargo_metadata",
- "chrono",
- "convert_case 0.6.0",
- "elliptic-curve",
- "ethabi",
- "generic-array 0.14.6",
- "hex",
- "k256",
- "once_cell",
- "open-fastrlp",
- "proc-macro2",
- "rand 0.8.5",
- "rlp",
- "rlp-derive",
- "serde",
- "serde_json",
- "strum",
- "syn 1.0.109",
- "thiserror",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2555,28 +2280,11 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9713f525348e5dde025d09b0a4217429f8074e8ff22c886263cc191e87d8216"
-dependencies = [
- "ethers-core 1.0.2",
- "getrandom 0.2.8",
- "reqwest",
- "semver 1.0.16",
- "serde",
- "serde-aux",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "ethers-etherscan"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d769437fafd0b47ea8b95e774e343c5195c77423f0f54b48d11c0d9ed2148ad"
 dependencies = [
- "ethers-core 2.0.0",
+ "ethers-core",
  "getrandom 0.2.8",
  "reqwest",
  "semver 1.0.16",
@@ -2585,32 +2293,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71df7391b0a9a51208ffb5c7f2d068900e99d6b3128d3a4849d138f194778b7"
-dependencies = [
- "async-trait",
- "auto_impl 0.5.0",
- "ethers-contract 1.0.2",
- "ethers-core 1.0.2",
- "ethers-etherscan 1.0.2",
- "ethers-providers 1.0.2",
- "ethers-signers 1.0.2",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio 1.26.0",
- "tracing",
- "tracing-futures",
- "url",
 ]
 
 [[package]]
@@ -2620,12 +2302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7dd311b76eab9d15209e4fd16bb419e25543709cbdf33079e8923dfa597517c"
 dependencies = [
  "async-trait",
- "auto_impl 1.0.1",
- "ethers-contract 2.0.0",
- "ethers-core 2.0.0",
- "ethers-etherscan 2.0.0",
- "ethers-providers 2.0.0",
- "ethers-signers 2.0.0",
+ "auto_impl",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
  "futures-locks",
  "futures-util",
  "instant",
@@ -2641,51 +2323,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a9e0597aa6b2fdc810ff58bc95e4eeaa2c219b3e615ed025106ecb027407d8"
-dependencies = [
- "async-trait",
- "auto_impl 1.0.1",
- "base64 0.13.1",
- "ethers-core 1.0.2",
- "futures-core",
- "futures-timer",
- "futures-util",
- "getrandom 0.2.8",
- "hashers",
- "hex",
- "http",
- "once_cell",
- "parking_lot 0.11.2",
- "pin-project 1.0.12",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio 1.26.0",
- "tokio-tungstenite 0.17.2",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-timer",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-providers"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7174af93619e81844d3d49887106a3721e5caecdf306e0b824bfb4316db3be"
 dependencies = [
  "async-trait",
- "auto_impl 1.0.1",
+ "auto_impl",
  "base64 0.21.0",
  "enr",
- "ethers-core 2.0.0",
+ "ethers-core",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -2709,24 +2355,6 @@ dependencies = [
  "wasm-timer",
  "web-sys",
  "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f41ced186867f64773db2e55ffdd92959e094072a1d09a5e5e831d443204f98"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "elliptic-curve",
- "eth-keystore",
- "ethers-core 1.0.2",
- "hex",
- "rand 0.8.5",
- "sha2 0.10.6",
- "thiserror",
 ]
 
 [[package]]
@@ -2740,44 +2368,12 @@ dependencies = [
  "coins-bip39",
  "elliptic-curve",
  "eth-keystore",
- "ethers-core 2.0.0",
+ "ethers-core",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.6",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe9c0a6d296c57191e5f8a613a3b5e816812c28f4a28d6178a17c21db903d77"
-dependencies = [
- "cfg-if 1.0.0",
- "dunce",
- "ethers-core 1.0.2",
- "getrandom 0.2.8",
- "glob",
- "hex",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.16",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror",
- "tiny-keccak",
- "tokio 1.26.0",
- "tracing",
- "walkdir",
- "yansi",
 ]
 
 [[package]]
@@ -2868,22 +2464,6 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -3374,15 +2954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,18 +3197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console 0.15.5",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,15 +3288,6 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -3867,38 +3417,6 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
-dependencies = [
- "ascii-canvas",
- "atty",
- "bit-set",
- "diff",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
-dependencies = [
- "regex",
 ]
 
 [[package]]
@@ -4080,15 +3598,6 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
-
-[[package]]
-name = "md-5"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
-dependencies = [
- "digest 0.10.6",
-]
 
 [[package]]
 name = "memchr"
@@ -4307,12 +3816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,12 +3931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4479,7 +3976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
 dependencies = [
  "arrayvec 0.7.2",
- "auto_impl 1.0.1",
+ "auto_impl",
  "bytes 1.4.0",
  "ethereum-types 0.14.1",
  "open-fastrlp-derive",
@@ -4663,12 +4160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,16 +4230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,56 +4238,6 @@ dependencies = [
  "futures",
  "rustc_version 0.4.0",
 ]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -4889,12 +4320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4973,12 +4398,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -5480,7 +4899,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -5899,17 +5318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.6",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5995,12 +5403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6070,20 +5472,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
-]
-
-[[package]]
-name = "solang-parser"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8ac4bfef383f368bd9bb045107a501cd9cd0b64ad1983e1b7e839d6a44ecad"
-dependencies = [
- "itertools",
- "lalrpop",
- "lalrpop-util",
- "phf",
- "unicode-xid",
+ "sha-1",
 ]
 
 [[package]]
@@ -6471,19 +5860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "string_cache"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot 0.12.1",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6654,37 +6030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "svm-rs"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
-dependencies = [
- "anyhow",
- "cfg-if 1.0.0",
- "clap 3.2.23",
- "console 0.14.1",
- "dialoguer",
- "fs2",
- "hex",
- "home",
- "indicatif",
- "itertools",
- "once_cell",
- "rand 0.8.5",
- "reqwest",
- "semver 1.0.16",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tempfile",
- "thiserror",
- "tokio 1.26.0",
- "tracing",
- "url",
- "zip",
-]
-
-[[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
 source = "git+https://github.com/webb-tools/lighthouse.git?branch=develop#913b28fb46ad651d3b6ca1efbfc85b68c3d314e3"
@@ -6759,33 +6104,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6867,22 +6191,6 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-dependencies = [
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tiny-bip39"
@@ -7018,22 +6326,6 @@ dependencies = [
  "pin-project 0.4.30",
  "tokio 0.2.25",
  "tungstenite 0.11.1",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "tokio 1.26.0",
- "tokio-rustls",
- "tungstenite 0.17.3",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -7364,30 +6656,9 @@ dependencies = [
  "input_buffer",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.8",
+ "sha-1",
  "url",
  "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
-dependencies = [
- "base64 0.13.1",
- "byteorder",
- "bytes 1.4.0",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls",
- "sha-1 0.10.1",
- "thiserror",
- "url",
- "utf-8",
- "webpki",
 ]
 
 [[package]]
@@ -7972,7 +7243,7 @@ version = "0.5.19"
 source = "git+https://github.com/webb-tools/webb-rs#734dd92eb0a8b867058d97c911b4c8bacc522962"
 dependencies = [
  "async-trait",
- "ethers 2.0.0",
+ "ethers",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -7988,7 +7259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "426649fd51964143b49326891ba1d5a10f166645f7b5a16794a0045e8361ad27"
 dependencies = [
  "async-trait",
- "ethers 2.0.0",
+ "ethers",
  "hex",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -8171,6 +7442,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webb-price-oracle-backends"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "coingecko",
+ "futures",
+ "native-tls",
+ "serde",
+ "typed-builder 0.12.0",
+ "webb 0.5.21",
+ "webb-relayer-store",
+ "webb-relayer-utils 0.1.0",
+]
+
+[[package]]
 name = "webb-proposal-signing-backends"
 version = "0.1.0"
 dependencies = [
@@ -8274,8 +7561,6 @@ dependencies = [
 name = "webb-relayer-context"
 version = "0.1.0"
 dependencies = [
- "coingecko",
- "ethers 1.0.2",
  "native-tls",
  "sp-core",
  "tokio 1.26.0",
@@ -8686,12 +7971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
 name = "yap"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8716,54 +7995,4 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "synstructure",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
-dependencies = [
- "aes 0.7.5",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
- "sha1",
- "time 0.3.20",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7565,6 +7565,7 @@ dependencies = [
  "sp-core",
  "tokio 1.26.0",
  "webb 0.5.21",
+ "webb-price-oracle-backends",
  "webb-relayer-config",
  "webb-relayer-store",
  "webb-relayer-utils 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8342,6 +8342,7 @@ dependencies = [
  "tokio 1.27.0",
  "tracing",
  "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb-price-oracle-backends",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,7 @@ repository = "https://github.com/webb-tools/relayer"
 edition = "2021"
 
 [workspace]
-members = [
-    ".",
-    "crates/*",
-    "event-watchers/*",
-    "services/*",
-]
+members = [".", "crates/*", "event-watchers/*", "services/*"]
 
 [workspace.dependencies]
 webb-bridge-registry-backends = { path = "crates/bridge-registry-backends" }
@@ -22,8 +17,8 @@ webb-relayer-handlers = { path = "crates/relayer-handlers" }
 webb-relayer-store = { path = "crates/relayer-store" }
 webb-relayer-config = { path = "crates/relayer-config" }
 webb-relayer-context = { path = "crates/relayer-context" }
-webb-relayer-utils = { path = "crates/relayer-utils"}
-webb-event-watcher-traits = { path = "crates/event-watcher-traits"}
+webb-relayer-utils = { path = "crates/relayer-utils" }
+webb-event-watcher-traits = { path = "crates/event-watcher-traits" }
 webb-ew-dkg = { path = "event-watchers/dkg" }
 webb-ew-evm = { path = "event-watchers/evm" }
 webb-ew-substrate = { path = "event-watchers/substrate" }
@@ -31,6 +26,7 @@ webb-relayer-handler-utils = { path = "crates/relayer-handler-utils" }
 webb-relayer-types = { path = "crates/relayer-types" }
 webb-relayer = { path = "services/webb-relayer" }
 
+thiserror = "^1"
 anyhow = "^1"
 tracing = { version = "^0.1", features = ["log"] }
 url = { version = "^2.3", features = ["serde"] }
@@ -39,7 +35,7 @@ tokio = { version = "^1", features = ["full"] }
 config = { version = "0.13", default-features = false, features = ["toml", "json"] }
 serde_json = { version = "^1", default-features = false }
 paw = { version = "^1.0" }
-webb = { version="0.5.21", default-features = false }
+webb = { version = "0.5.21", default-features = false }
 sp-core = { version = "16.0.0", default-features = false }
 sp-runtime = { version = "18.0.0", default-features = false }
 # Used by ethers (but we need it to be vendored with the lib).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 members = [".", "crates/*", "event-watchers/*", "services/*"]
 
 [workspace.dependencies]
+webb-price-oracle-backends = { path = "crates/price-oracle-backends" }
 webb-bridge-registry-backends = { path = "crates/bridge-registry-backends" }
 webb-proposal-signing-backends = { path = "crates/proposal-signing-backends" }
 webb-relayer-tx-queue = { path = "crates/tx-queue" }

--- a/crates/price-oracle-backends/Cargo.toml
+++ b/crates/price-oracle-backends/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "webb-relayer-store"
+name = "webb-price-oracle-backends"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -8,25 +8,22 @@ documentation = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 webb-relayer-utils = { workspace = true }
-
-tracing = { workspace = true }
-sled = { workspace = true, optional = true }
+webb-relayer-store = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
-hex = { workspace = true }
 webb = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
 native-tls = { workspace = true, optional = true }
-webb-proposals = { workspace = true }
-tempfile = { workspace = true }
 
-parking_lot = "^0.12"
+chrono = { version = "0.4.23", features = ["serde"] }
+typed-builder = "0.12.0"
+# Backends for the price oracle.
+coingecko = { version = "1.0.1", optional = true }
 
 [features]
-default = ["std", "sled"]
+default = ["std", "coingecko"]
+coingecko = ["dep:coingecko"]
 std = []
-sled = ["dep:sled"]

--- a/crates/price-oracle-backends/Cargo.toml
+++ b/crates/price-oracle-backends/Cargo.toml
@@ -21,9 +21,14 @@ native-tls = { workspace = true, optional = true }
 chrono = { version = "0.4.23", features = ["serde"] }
 typed-builder = "0.12.0"
 # Backends for the price oracle.
-coingecko = { version = "1.0.1", optional = true }
+reqwest = { version = "0.11", features = ["json"], optional = true }
+
+
+[dev-dependencies]
+tokio = { workspace = true }
+axum = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["std"]
-coingecko = ["dep:coingecko"]
+coingecko = ["dep:reqwest"]
 std = []

--- a/crates/price-oracle-backends/Cargo.toml
+++ b/crates/price-oracle-backends/Cargo.toml
@@ -24,6 +24,6 @@ typed-builder = "0.12.0"
 coingecko = { version = "1.0.1", optional = true }
 
 [features]
-default = ["std", "coingecko"]
+default = ["std"]
 coingecko = ["dep:coingecko"]
 std = []

--- a/crates/price-oracle-backends/src/cached.rs
+++ b/crates/price-oracle-backends/src/cached.rs
@@ -16,20 +16,33 @@ pub struct CachedPriceBackend<B, S> {
     backend: B,
     /// The local data store used for caching
     store: S,
-    /// The cache expiration time in seconds
+    /// The cache expiration time.
+    ///
     /// If the cache is older than this value, it will be refreshed
+    /// from the source backend.
+    ///
     /// If the value is `None`, the cache will never expire
-    /// The default value is `15 minutes`.
+    /// and will never be refreshed. **This may lead to incorrect price data.**
+    ///
+    /// Use this option only if you are sure that the source backend is always available.
+    /// Otherwise, use a reasonable value, The default value is `15 minutes`.
+    /// see [`Self::use_cache_if_source_unavailable`] and [`Self::even_if_expired`]
+    /// for fine tuning the cache behavior.
     #[builder(default = Some(Duration::from_secs(15 * 60)))]
     cache_expiration: Option<Duration>,
     /// Specifies whether the cache should be returned even if the source is unavailable
     ///
     /// If the value is `true`, the cache will be returned even if the source
-    /// backend is unavailable even if the cache is expired.
+    /// backend is unavailable unless the cache is expired.
+    ///
+    /// see [`Self::even_if_expired`] if you want to return the cache even if it is expired.
     #[builder(setter(strip_bool))]
     use_cache_if_source_unavailable: bool,
     /// Specifies whether the cache should be returned even if it is expired
     /// in case the source is unavailable.
+    ///
+    /// see [`Self::use_cache_if_source_unavailable`] if you want to return the cache
+    /// even if the source is unavailable.
     #[builder(setter(strip_bool))]
     even_if_expired: bool,
 }

--- a/crates/price-oracle-backends/src/cached.rs
+++ b/crates/price-oracle-backends/src/cached.rs
@@ -28,6 +28,10 @@ pub struct CachedPriceBackend<B, S> {
     /// backend is unavailable even if the cache is expired.
     #[builder(setter(strip_bool))]
     use_cache_if_source_unavailable: bool,
+    /// Specifies whether the cache should be returned even if it is expired
+    /// in case the source is unavailable.
+    #[builder(setter(strip_bool))]
+    even_if_expired: bool,
 }
 
 /// A cached price data
@@ -113,6 +117,7 @@ where
                 .backend
                 .get_prices_vs_currency(&token_ids, vs_currency)
                 .await;
+            let soruce_unavailable = result.is_err();
             let updated_prices = match result {
                 Ok(updated_prices) => updated_prices,
                 Err(err) => {
@@ -125,17 +130,35 @@ where
                 }
             };
 
-            // Update the cache
-            for (token, price) in updated_prices {
-                let token_key = format!("{token}/{vs_currency}");
-                prices.insert(token.clone(), price);
-                self.store.insert_price(
-                    &token_key,
-                    CachedPrice {
-                        price,
-                        timestamp: Utc::now().timestamp(),
-                    },
-                )?;
+            // If the source is unavailable and the cache is enabled and `even_if_expired` is enabled,
+            // return the cache
+            if soruce_unavailable
+                && self.use_cache_if_source_unavailable
+                && self.even_if_expired
+            {
+                // refetch the cache, and ignore the expiration
+                for token in tokens {
+                    let token_key = format!("{token}/{vs_currency}");
+                    if let Some(cached) = self.store.get_price(&token_key)? {
+                        prices.insert((*token).to_owned(), cached.price);
+                    }
+                }
+            }
+
+            // Update the cache, only if the source is available
+            let soruce_available = !soruce_unavailable;
+            if soruce_available {
+                for (token, price) in updated_prices {
+                    let token_key = format!("{token}/{vs_currency}");
+                    prices.insert(token.clone(), price);
+                    self.store.insert_price(
+                        &token_key,
+                        CachedPrice {
+                            price,
+                            timestamp: Utc::now().timestamp(),
+                        },
+                    )?;
+                }
             }
         }
         Ok(prices)

--- a/crates/price-oracle-backends/src/cached.rs
+++ b/crates/price-oracle-backends/src/cached.rs
@@ -1,0 +1,143 @@
+use std::{collections::HashSet, time::Duration};
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use webb_relayer_store::TokenPriceCacheStore;
+use webb_relayer_utils::Result;
+
+/// A price backend that caches the price data in a local database
+///
+/// The cache is used to reduce the number of requests to the source and to improve the performance.
+///
+/// **Note:** depending on the configuration, this backend may be used to return the last saved price
+/// data even if the source is unavailable, which may lead to incorrect price data.
+#[derive(Debug, Clone, typed_builder::TypedBuilder)]
+pub struct CachedPriceBackend<B, S> {
+    /// The price backend
+    backend: B,
+    /// The local data store used for caching
+    store: S,
+    /// The cache expiration time in seconds
+    /// If the cache is older than this value, it will be refreshed
+    /// If the value is `None`, the cache will never expire
+    /// The default value is `15 minutes`.
+    #[builder(default = Some(Duration::from_secs(15 * 60)), setter(strip_option))]
+    cache_expiration: Option<Duration>,
+    /// Specifies whether the cache should be returned even if the source is unavailable
+    ///
+    /// If the value is `true`, the cache will be returned even if the source
+    /// backend is unavailable even if the cache is expired.
+    #[builder(setter(strip_bool))]
+    use_cache_if_source_unavailable: bool,
+}
+
+/// A cached price data
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct CachedPrice {
+    /// The Cached Price of the token
+    pub price: f64,
+    /// The timestamp of the cached price
+    pub timestamp: i64,
+}
+
+impl<B, S> CachedPriceBackend<B, S>
+where
+    B: super::PriceBackend,
+    S: TokenPriceCacheStore<CachedPrice>,
+{
+    /// Returns the cache expiration duration
+    pub const fn cache_expiration(&self) -> Option<Duration> {
+        self.cache_expiration
+    }
+
+    /// Returns `true` if the cache should be returned even if the source is unavailable
+    pub const fn use_cache_if_source_unavailable_enabled(&self) -> bool {
+        self.use_cache_if_source_unavailable
+    }
+
+    /// Returns the inner price backend
+    pub const fn inner(&self) -> &B {
+        &self.backend
+    }
+
+    /// Returns the inner data store
+    /// The data store is used for caching the price data
+    pub const fn store(&self) -> &S {
+        &self.store
+    }
+}
+
+#[async_trait::async_trait]
+impl<B, S> super::PriceBackend for CachedPriceBackend<B, S>
+where
+    B: super::PriceBackend + Clone + 'static,
+    S: TokenPriceCacheStore<CachedPrice> + Clone + Send + Sync + 'static,
+{
+    async fn get_prices_vs_currency(
+        &self,
+        tokens: &[&str],
+        vs_currency: super::FiatCurrency,
+    ) -> Result<super::PricesMap> {
+        // The returned prices map
+        let mut prices = super::PricesMap::new();
+        // The tokens that need to be fetched from the source
+        let mut tokens_to_fetch = HashSet::new();
+
+        for token in tokens {
+            let token_key = format!("{token}/{vs_currency}");
+            // Check if the token is cached
+            if let Some(cached) = self.store.get_price(&token_key)? {
+                let expired =
+                    self.cache_expiration.map_or(false, |expiration| {
+                        let ts = NaiveDateTime::from_timestamp_opt(
+                            cached.timestamp + expiration.as_secs() as i64,
+                            Default::default(),
+                        )
+                        .expect("Time went backwards");
+                        DateTime::<Utc>::from_utc(ts, Utc) < Utc::now()
+                    });
+                // If the cache is expired, add the token to the list of tokens to fetch
+                if expired {
+                    tokens_to_fetch.insert(token.to_owned());
+                } else {
+                    prices.insert(token_key, cached.price);
+                }
+            } else {
+                // If the token is not cached, add it to the list of tokens to fetch
+                tokens_to_fetch.insert(token.to_owned());
+            }
+        }
+        if !tokens_to_fetch.is_empty() {
+            // Fetch the prices from the source
+            let token_ids = tokens_to_fetch.iter().copied().collect::<Vec<_>>();
+            let result = self
+                .backend
+                .get_prices_vs_currency(&token_ids, vs_currency)
+                .await;
+            let updated_prices = match result {
+                Ok(updated_prices) => updated_prices,
+                Err(err) => {
+                    // If the source is unavailable and the cache is enabled, return the cache
+                    if self.use_cache_if_source_unavailable {
+                        super::PricesMap::new()
+                    } else {
+                        return Err(err);
+                    }
+                }
+            };
+
+            // Update the cache
+            for (token, price) in updated_prices {
+                let token_key = format!("{token}/{vs_currency}");
+                prices.insert(token_key.clone(), price);
+                self.store.insert_price(
+                    &token_key,
+                    CachedPrice {
+                        price,
+                        timestamp: Utc::now().timestamp(),
+                    },
+                )?;
+            }
+        }
+        Ok(prices)
+    }
+}

--- a/crates/price-oracle-backends/src/coingecko.rs
+++ b/crates/price-oracle-backends/src/coingecko.rs
@@ -1,0 +1,55 @@
+//! Price Backend implementation for CoinGecko
+
+use std::sync::Arc;
+
+use futures::TryFutureExt;
+use webb_relayer_utils::Result;
+
+/// A backend for fetching prices from CoinGecko
+#[derive(Clone, Default)]
+pub struct CoinGeckoBackend {
+    client: Arc<coingecko::CoinGeckoClient>,
+}
+
+impl std::fmt::Debug for CoinGeckoBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoinGeckoBackend")
+            .field("client", &"CoinGeckoClient")
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl super::PriceBackend for CoinGeckoBackend {
+    async fn get_prices_vs_currency<T>(
+        &self,
+        tokens: T,
+        currency: super::FiatCurrency,
+    ) -> Result<super::PricesMap>
+    where
+        T: IntoIterator + Send + Sync,
+        T::Item: AsRef<str>,
+    {
+        let token_ids = tokens
+            .into_iter()
+            .map(|token| token.as_ref().to_owned())
+            .collect::<Vec<_>>();
+        let prices = self
+            .client
+            .price(
+                &token_ids,
+                &[currency.to_string()],
+                false,
+                false,
+                false,
+                false,
+            )
+            .map_ok(|m| {
+                m.into_iter()
+                    .filter_map(|(k, v)| v.usd.map(|price| (k, price)))
+                    .collect()
+            })
+            .await?;
+        Ok(prices)
+    }
+}

--- a/crates/price-oracle-backends/src/coingecko.rs
+++ b/crates/price-oracle-backends/src/coingecko.rs
@@ -1,31 +1,54 @@
 //! Price Backend implementation for `CoinGecko`
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use futures::TryFutureExt;
+use serde::de::DeserializeOwned;
 use webb_relayer_utils::Result;
 
 /// A backend for fetching prices from `CoinGecko`
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, typed_builder::TypedBuilder)]
 pub struct CoinGeckoBackend {
-    client: Arc<coingecko::CoinGeckoClient>,
+    #[builder(
+        default = String::from("https://api.coingecko.com/api/v3"),
+        setter(into)
+    )]
+    host: String,
+    #[builder(default = Arc::new(reqwest::Client::new()))]
+    client: Arc<reqwest::Client>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SimplePriceResponse {
+    pub(crate) usd: Option<f64>,
 }
 
 impl CoinGeckoBackend {
-    /// Creates a new `CoinGeckoBackend` with the custom [`coingecko::CoinGeckoClient`]
-    #[must_use]
-    pub fn with_coin_gecko_client(client: coingecko::CoinGeckoClient) -> Self {
-        Self {
-            client: Arc::new(client),
-        }
+    async fn get<R: DeserializeOwned>(&self, endpoint: &str) -> Result<R> {
+        let url = format!("{}/{}", self.host, endpoint);
+        self.client
+            .get(&url)
+            .send()
+            .await?
+            .json()
+            .await
+            .map_err(Into::into)
     }
-}
 
-impl std::fmt::Debug for CoinGeckoBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CoinGeckoBackend")
-            .field("client", &"CoinGeckoClient")
-            .finish()
+    async fn price<Id: AsRef<str>, Curr: AsRef<str>>(
+        &self,
+        ids: &[Id],
+        vs_currencies: &[Curr],
+    ) -> Result<HashMap<String, SimplePriceResponse>> {
+        let ids = ids.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+        let vs_currencies =
+            vs_currencies.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+        let req = format!(
+            "simple/price?ids={}&vs_currencies={}",
+            ids.join("%2C"),
+            vs_currencies.join("%2C")
+        );
+        self.get(&req).await
     }
 }
 
@@ -37,15 +60,7 @@ impl super::PriceBackend for CoinGeckoBackend {
         currency: super::FiatCurrency,
     ) -> Result<super::PricesMap> {
         let prices = self
-            .client
-            .price(
-                tokens,
-                &[currency.to_string().to_lowercase()],
-                false,
-                false,
-                false,
-                false,
-            )
+            .price(tokens, &[currency.to_string().to_lowercase()])
             .map_ok(|m| {
                 m.into_iter()
                     .filter_map(|(k, v)| v.usd.map(|price| (k, price)))
@@ -53,5 +68,217 @@ impl super::PriceBackend for CoinGeckoBackend {
             })
             .await?;
         Ok(prices)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::PriceBackend;
+
+    use super::*;
+    use coingecko_mocked_server::*;
+
+    mod coingecko_mocked_server {
+        use axum::extract::{Query, State};
+        use axum::response::IntoResponse;
+        use axum::{response::Json, routing::get, Router};
+        use std::collections::HashMap;
+        use std::net::SocketAddr;
+        use std::sync::atomic::Ordering;
+        use std::{
+            sync::{atomic::AtomicBool, Arc},
+            time::Duration,
+        };
+
+        fn random_free_port() -> u16 {
+            std::net::TcpListener::bind("127.0.0.1:0")
+                .unwrap()
+                .local_addr()
+                .unwrap()
+                .port()
+        }
+
+        #[derive(Debug, Clone, typed_builder::TypedBuilder)]
+        pub struct MockServer {
+            hard_coded_prices: crate::PricesMap,
+            #[builder(
+                default = Arc::new(Duration::from_secs(0)),
+                setter(transform = |d: Duration| Arc::new(d))
+            )]
+            simulated_delay: Arc<std::time::Duration>,
+            #[builder(
+                default,
+                setter(transform = |b: bool| Arc::new(AtomicBool::new(b))),
+            )]
+            simulat_server_error: Arc<AtomicBool>,
+        }
+
+        pub struct MockedServerHandle {
+            simulat_server_error: Arc<AtomicBool>,
+            backend: super::CoinGeckoBackend,
+            server_thread: tokio::task::JoinHandle<()>,
+        }
+
+        impl Drop for MockedServerHandle {
+            fn drop(&mut self) {
+                self.simulat_server_error.store(true, Ordering::Relaxed);
+                self.server_thread.abort();
+            }
+        }
+
+        impl MockedServerHandle {
+            pub fn backend(&self) -> super::CoinGeckoBackend {
+                self.backend.clone()
+            }
+
+            /// Simulate a server error, this will cause all requests to fail
+            pub fn simulate_server_error(&self, v: bool) {
+                self.simulat_server_error.store(v, Ordering::Relaxed);
+            }
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RequestQuery {
+            ids: String,
+            #[allow(dead_code)]
+            vs_currencies: String,
+        }
+
+        #[derive(Clone)]
+        struct MockState {
+            hard_coded_prices: crate::PricesMap,
+            simulated_delay: Arc<std::time::Duration>,
+            simulat_server_error: Arc<AtomicBool>,
+        }
+
+        async fn prices_handler(
+            Query(query): Query<RequestQuery>,
+            State(mock_state): State<MockState>,
+        ) -> impl IntoResponse {
+            if mock_state.simulat_server_error.load(Ordering::Relaxed) {
+                return Err(Json("Simulated Server Error"));
+            }
+
+            let mut prices = HashMap::new();
+            for token in query.ids.split(',') {
+                if let Some(price) = mock_state.hard_coded_prices.get(token) {
+                    prices.insert(
+                        token.to_string(),
+                        super::SimplePriceResponse { usd: Some(*price) },
+                    );
+                }
+            }
+
+            tokio::time::sleep(*mock_state.simulated_delay).await;
+            Ok(Json(prices))
+        }
+
+        impl MockServer {
+            pub fn spwan(self) -> MockedServerHandle {
+                let simulat_server_error = self.simulat_server_error.clone();
+                let port = random_free_port();
+                let addr = SocketAddr::from(([127, 0, 0, 1], port));
+                let url = format!("http://{addr}/api/v3");
+                let backend =
+                    super::CoinGeckoBackend::builder().host(url).build();
+                let handle = tokio::spawn(async move {
+                    let api_v3 = Router::new()
+                        .route("/simple/price", get(prices_handler));
+                    let app = Router::new()
+                        .nest("/api/v3/", api_v3)
+                        .with_state(MockState {
+                            hard_coded_prices: self.hard_coded_prices,
+                            simulated_delay: self.simulated_delay.clone(),
+                            simulat_server_error: self
+                                .simulat_server_error
+                                .clone(),
+                        });
+
+                    axum::Server::bind(&addr)
+                        .serve(app.into_make_service())
+                        .await
+                        .unwrap();
+                });
+
+                MockedServerHandle {
+                    simulat_server_error,
+                    backend,
+                    server_thread: handle,
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn it_works() {
+        let mock_server = MockServer::builder()
+            .hard_coded_prices({
+                let mut prices = crate::PricesMap::new();
+                prices.insert(String::from("ETH"), 1000.0);
+                prices.insert(String::from("BTC"), 20000.0);
+                prices
+            })
+            .build();
+        let handle = mock_server.spwan();
+        // Wait for the server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let backend = handle.backend();
+        let prices = backend.get_prices(&["ETH", "BTC"]).await.unwrap();
+        assert_eq!(prices.get("ETH"), Some(&1000.0));
+        assert_eq!(prices.get("BTC"), Some(&20000.0));
+    }
+
+    #[tokio::test]
+    async fn fails_when_server_errors() {
+        let mock_server = MockServer::builder()
+            .hard_coded_prices({
+                let mut prices = crate::PricesMap::new();
+                prices.insert(String::from("ETH"), 1000.0);
+                prices.insert(String::from("BTC"), 20000.0);
+                prices
+            })
+            .build();
+        let handle = mock_server.spwan();
+        // Wait for the server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let backend = handle.backend();
+        handle.simulate_server_error(true);
+        let prices = backend.get_prices(&["ETH", "BTC"]).await;
+        assert!(prices.is_err());
+    }
+
+    #[tokio::test]
+    async fn should_keep_working_if_cached() {
+        let mock_server = MockServer::builder()
+            .hard_coded_prices({
+                let mut prices = crate::PricesMap::new();
+                prices.insert(String::from("ETH"), 1000.0);
+                prices.insert(String::from("BTC"), 20000.0);
+                prices
+            })
+            .build();
+        let handle = mock_server.spwan();
+        // Wait for the server to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let backend = handle.backend();
+        let cached_backend = crate::CachedPriceBackend::builder()
+            .backend(backend)
+            .store(webb_relayer_store::InMemoryStore::default())
+            .use_cache_if_source_unavailable()
+            // Disable cache expiration
+            .cache_expiration(None)
+            .build();
+        let prices = cached_backend.get_prices(&["ETH", "BTC"]).await.unwrap();
+        assert_eq!(prices.get("ETH"), Some(&1000.0));
+        assert_eq!(prices.get("BTC"), Some(&20000.0));
+
+        // Simulate a server error
+        handle.simulate_server_error(true);
+        // The cache should still work
+        let prices = cached_backend.get_prices(&["ETH", "BTC"]).await.unwrap();
+        assert_eq!(prices.get("ETH"), Some(&1000.0));
+        assert_eq!(prices.get("BTC"), Some(&20000.0));
     }
 }

--- a/crates/price-oracle-backends/src/dummy.rs
+++ b/crates/price-oracle-backends/src/dummy.rs
@@ -1,0 +1,36 @@
+use webb_relayer_utils::Result;
+
+/// A Dummy Price Oracle Backend
+///
+/// This backend is useful for testing purposes, it always returns the same price data
+/// that is configured initially while creating the backend.
+#[derive(Debug, Clone)]
+pub struct DummyPriceBackend {
+    /// The price data that is returned by the backend
+    prices: super::PricesMap,
+}
+
+impl DummyPriceBackend {
+    /// Creates a new dummy price backend
+    #[must_use]
+    pub fn new(prices: super::PricesMap) -> Self {
+        Self { prices }
+    }
+}
+
+#[async_trait::async_trait]
+impl super::PriceBackend for DummyPriceBackend {
+    async fn get_prices_vs_currency(
+        &self,
+        tokens: &[&str],
+        _currency: super::FiatCurrency,
+    ) -> Result<super::PricesMap> {
+        let result = self
+            .prices
+            .iter()
+            .filter(|(token, _)| tokens.contains(&token.as_str()))
+            .map(|(token, price)| (token.clone(), *price))
+            .collect();
+        Ok(result)
+    }
+}

--- a/crates/price-oracle-backends/src/lib.rs
+++ b/crates/price-oracle-backends/src/lib.rs
@@ -25,21 +25,21 @@
 //! - [CoinGecko](https://www.coingecko.com/en/api)
 //!
 //! ## Usage
-//! ```rust,no_run
-//! use price_oracle_backends::{CoinGeckoBackend, PriceBackend};
-//! let backend = CoinGeckoBackend::new();
-//! let prices = backend.get_prices(&["ETH", "BTC"]).await?;
+//! ```rust,ignore
+//! use webb_price_oracle_backends::{CoinGeckoBackend, PriceBackend};
+//! let backend = CoinGeckoBackend::builder().build();
+//! let prices = backend.get_prices(&["ETH", "BTC"]).await.unwrap();
 //! let eth_price = prices.get("ETH").unwrap();
 //! let btc_price = prices.get("BTC").unwrap();
 //! ```
 //! ## With Cache
-//! ```rust,no_run
+//! ```rust,ignore
 //! use price_oracle_backends::{CoinGeckoBackend, PriceBackend, CachedPriceBackend};
 //! use webb_relayer_store::SledStore;
 //! let store = SledStore::temporary()?;
-//! let backend = CoinGeckoBackend::new();
+//! let backend = CoinGeckoBackend::builder().build();
 //! let backend = CachedPriceBackend::new(backend, store);
-//! let prices = backend.get_prices(&["ETH", "BTC"]).await?;
+//! let prices = backend.get_prices(&["ETH", "BTC"]).await.unwrap();
 //! let eth_price = prices.get("ETH").unwrap();
 //! let btc_price = prices.get("BTC").unwrap();
 //! ```

--- a/crates/price-oracle-backends/src/lib.rs
+++ b/crates/price-oracle-backends/src/lib.rs
@@ -29,8 +29,8 @@
 //! use price_oracle_backends::{CoinGeckoBackend, PriceBackend};
 //! let backend = CoinGeckoBackend::new();
 //! let prices = backend.get_prices(&["ETH", "BTC"]).await?;
-//! let eth_price = prices.get("ETH").expect("ETH price is missing");
-//! let btc_price = prices.get("BTC").expect("BTC price is missing");
+//! let eth_price = prices.get("ETH").unwrap();
+//! let btc_price = prices.get("BTC").unwrap();
 //! ```
 //! ## With Cache
 //! ```rust,no_run
@@ -40,28 +40,35 @@
 //! let backend = CoinGeckoBackend::new();
 //! let backend = CachedPriceBackend::new(backend, store);
 //! let prices = backend.get_prices(&["ETH", "BTC"]).await?;
-//! let eth_price = prices.get("ETH").expect("ETH price is missing");
-//! let btc_price = prices.get("BTC").expect("BTC price is missing");
+//! let eth_price = prices.get("ETH").unwrap();
+//! let btc_price = prices.get("BTC").unwrap();
 //! ```
 //!
 //! ## Features flags
-//! - `coingecko` - enables CoinGecko backend
+//! - `coingecko` - enables `CoinGecko` backend
 
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
 
-use std::collections::HashSet;
 use std::fmt::Display;
-use std::time::Duration;
 
-use chrono::{DateTime, NaiveDateTime, Utc};
-use webb_relayer_store::TokenPriceCacheStore;
 use webb_relayer_utils::Result;
 
+/// Cached Backend Module
+mod cached;
+/// `CoinGecko` Backend
 #[cfg(feature = "coingecko")]
-pub mod coingecko;
+mod coingecko;
+/// A Dymmy Price Backend
+mod dummy;
+/// Merger Backend Module
+mod merger;
+
 #[cfg(feature = "coingecko")]
 pub use crate::coingecko::CoinGeckoBackend;
+pub use cached::CachedPriceBackend;
+pub use dummy::DummyPriceBackend;
+pub use merger::PriceOracleMerger;
 
 /// A List of supported fiat currencies
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -79,6 +86,7 @@ pub enum FiatCurrency {
 
 impl FiatCurrency {
     /// Returns the currency symbol
+    #[must_use]
     pub fn symbol(&self) -> &'static str {
         match self {
             Self::USD => "$",
@@ -107,11 +115,7 @@ pub trait PriceBackend: Send + Sync {
     /// Returns the prices for the given tokens in the USD currency
     ///
     /// This is a convenience method that calls `get_prices_vs_currency` with the default currency
-    async fn get_prices<T>(&self, tokens: T) -> Result<PricesMap>
-    where
-        T: IntoIterator + Send + Sync,
-        T::Item: AsRef<str>,
-    {
+    async fn get_prices(&self, tokens: &[&str]) -> Result<PricesMap> {
         PriceBackend::get_prices_vs_currency(
             self,
             tokens,
@@ -120,155 +124,9 @@ pub trait PriceBackend: Send + Sync {
         .await
     }
     /// Returns the prices for the given tokens in the requested currency
-    async fn get_prices_vs_currency<T>(
+    async fn get_prices_vs_currency(
         &self,
-        tokens: T,
+        tokens: &[&str],
         vs_currency: FiatCurrency,
-    ) -> Result<PricesMap>
-    where
-        T: IntoIterator + Send + Sync,
-        T::Item: AsRef<str>;
-}
-
-/// A price backend that caches the price data in a local database
-///
-/// The cache is used to reduce the number of requests to the source and to improve the performance.
-///
-/// **Note:** depending on the configuration, this backend may be used to return the last saved price
-/// data even if the source is unavailable, which may lead to incorrect price data.
-#[derive(Debug, Clone, typed_builder::TypedBuilder)]
-pub struct CachedPriceBackend<B, S> {
-    /// The price backend
-    backend: B,
-    /// The local data store used for caching
-    store: S,
-    /// The cache expiration time in seconds
-    /// If the cache is older than this value, it will be refreshed
-    /// If the value is `None`, the cache will never expire
-    /// The default value is `15 minutes`.
-    #[builder(default = Some(Duration::from_secs(15 * 60)), setter(strip_option))]
-    cache_expiration: Option<Duration>,
-    /// Specifies whether the cache should be returned even if the source is unavailable
-    ///
-    /// If the value is `true`, the cache will be returned even if the source
-    /// backend is unavailable even if the cache is expired.
-    #[builder(setter(strip_bool))]
-    use_cache_if_source_unavailable: bool,
-}
-
-/// A cached price data
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
-pub struct CachedPrice {
-    /// The Cached Price of the token
-    pub price: f64,
-    /// The timestamp of the cached price
-    pub timestamp: i64,
-}
-
-impl<B, S> CachedPriceBackend<B, S>
-where
-    B: PriceBackend,
-    S: TokenPriceCacheStore<CachedPrice>,
-{
-    /// Returns the cache expiration duration
-    pub const fn cache_expiration(&self) -> Option<Duration> {
-        self.cache_expiration
-    }
-
-    /// Returns `true` if the cache should be returned even if the source is unavailable
-    pub const fn use_cache_if_source_unavailable_enabled(&self) -> bool {
-        self.use_cache_if_source_unavailable
-    }
-
-    /// Returns the inner price backend
-    pub const fn inner(&self) -> &B {
-        &self.backend
-    }
-
-    /// Returns the inner data store
-    /// The data store is used for caching the price data
-    pub const fn store(&self) -> &S {
-        &self.store
-    }
-}
-
-#[async_trait::async_trait]
-impl<B, S> PriceBackend for CachedPriceBackend<B, S>
-where
-    B: PriceBackend + Clone + Send + Sync + 'static,
-    S: TokenPriceCacheStore<CachedPrice> + Clone + Send + Sync + 'static,
-{
-    async fn get_prices_vs_currency<T>(
-        &self,
-        tokens: T,
-        vs_currency: FiatCurrency,
-    ) -> Result<PricesMap>
-    where
-        T: IntoIterator + Send + Sync,
-        T::Item: AsRef<str>,
-    {
-        // The returned prices map
-        let mut prices = PricesMap::new();
-        // The tokens that need to be fetched from the source
-        let mut tokens_to_fetch = HashSet::new();
-
-        for token in tokens {
-            let token_key = format!("{}/{}", token.as_ref(), vs_currency);
-            // Check if the token is cached
-            if let Some(cached) = self.store.get_price(&token_key)? {
-                let expired = self
-                    .cache_expiration
-                    .map(|expiration| {
-                        let ts = NaiveDateTime::from_timestamp_opt(
-                            cached.timestamp + expiration.as_secs() as i64,
-                            Default::default(),
-                        )
-                        .expect("Time went backwards");
-                        DateTime::<Utc>::from_utc(ts, Utc) < Utc::now()
-                    })
-                    .unwrap_or(false);
-                // If the cache is expired, add the token to the list of tokens to fetch
-                if expired {
-                    tokens_to_fetch.insert(token.as_ref().to_owned());
-                } else {
-                    prices.insert(token_key, cached.price);
-                }
-            } else {
-                // If the token is not cached, add it to the list of tokens to fetch
-                tokens_to_fetch.insert(token.as_ref().to_owned());
-            }
-        }
-        if !tokens_to_fetch.is_empty() {
-            // Fetch the prices from the source
-            let result = self
-                .backend
-                .get_prices_vs_currency(&tokens_to_fetch, vs_currency)
-                .await;
-            let updated_prices = match result {
-                Ok(updated_prices) => updated_prices,
-                Err(err) => {
-                    // If the source is unavailable and the cache is enabled, return the cache
-                    if self.use_cache_if_source_unavailable {
-                        PricesMap::new()
-                    } else {
-                        return Err(err);
-                    }
-                }
-            };
-
-            // Update the cache
-            for (token, price) in updated_prices {
-                let token_key = format!("{}/{}", token, vs_currency);
-                prices.insert(token_key.clone(), price);
-                self.store.insert_price(
-                    &token_key,
-                    CachedPrice {
-                        price,
-                        timestamp: Utc::now().timestamp(),
-                    },
-                )?;
-            }
-        }
-        Ok(prices)
-    }
+    ) -> Result<PricesMap>;
 }

--- a/crates/price-oracle-backends/src/lib.rs
+++ b/crates/price-oracle-backends/src/lib.rs
@@ -1,0 +1,274 @@
+// Copyright 2022 Webb Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Price Oracle Backends
+//!
+//! A Price Oracle Backend is a service that provides price data for a list of tokens symbols in
+//! the requested currency. The backend is responsible for fetching the price data from the source
+//! and converting it to the requested currency.
+//!
+//! The backend may optionally cache the price data in a local database. The cache is used to
+//! reduce the number of requests to the source and to improve the performance of the backend.
+//!
+//! As of now, the following backends are supported:
+//! - [CoinGecko](https://www.coingecko.com/en/api)
+//!
+//! ## Usage
+//! ```rust,no_run
+//! use price_oracle_backends::{CoinGeckoBackend, PriceBackend};
+//! let backend = CoinGeckoBackend::new();
+//! let prices = backend.get_prices(&["ETH", "BTC"]).await?;
+//! let eth_price = prices.get("ETH").expect("ETH price is missing");
+//! let btc_price = prices.get("BTC").expect("BTC price is missing");
+//! ```
+//! ## With Cache
+//! ```rust,no_run
+//! use price_oracle_backends::{CoinGeckoBackend, PriceBackend, CachedPriceBackend};
+//! use webb_relayer_store::SledStore;
+//! let store = SledStore::temporary()?;
+//! let backend = CoinGeckoBackend::new();
+//! let backend = CachedPriceBackend::new(backend, store);
+//! let prices = backend.get_prices(&["ETH", "BTC"]).await?;
+//! let eth_price = prices.get("ETH").expect("ETH price is missing");
+//! let btc_price = prices.get("BTC").expect("BTC price is missing");
+//! ```
+//!
+//! ## Features flags
+//! - `coingecko` - enables CoinGecko backend
+
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
+use std::collections::HashSet;
+use std::fmt::Display;
+use std::time::Duration;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use webb_relayer_store::TokenPriceCacheStore;
+use webb_relayer_utils::Result;
+
+#[cfg(feature = "coingecko")]
+pub mod coingecko;
+#[cfg(feature = "coingecko")]
+pub use crate::coingecko::CoinGeckoBackend;
+
+/// A List of supported fiat currencies
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FiatCurrency {
+    /// United States Dollar
+    ///
+    /// The default currency
+    #[default]
+    USD,
+    /// Euro
+    EUR,
+    /// British Pound
+    GBP,
+}
+
+impl FiatCurrency {
+    /// Returns the currency symbol
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            Self::USD => "$",
+            Self::EUR => "€",
+            Self::GBP => "£",
+        }
+    }
+}
+
+impl Display for FiatCurrency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::USD => write!(f, "USD"),
+            Self::EUR => write!(f, "EUR"),
+            Self::GBP => write!(f, "GBP"),
+        }
+    }
+}
+
+/// A type alias for a map of token symbols to prices
+type PricesMap = std::collections::HashMap<String, f64>;
+
+/// A trait for a price backend
+#[async_trait::async_trait]
+pub trait PriceBackend: Send + Sync {
+    /// Returns the prices for the given tokens in the USD currency
+    ///
+    /// This is a convenience method that calls `get_prices_vs_currency` with the default currency
+    async fn get_prices<T>(&self, tokens: T) -> Result<PricesMap>
+    where
+        T: IntoIterator + Send + Sync,
+        T::Item: AsRef<str>,
+    {
+        PriceBackend::get_prices_vs_currency(
+            self,
+            tokens,
+            FiatCurrency::default(),
+        )
+        .await
+    }
+    /// Returns the prices for the given tokens in the requested currency
+    async fn get_prices_vs_currency<T>(
+        &self,
+        tokens: T,
+        vs_currency: FiatCurrency,
+    ) -> Result<PricesMap>
+    where
+        T: IntoIterator + Send + Sync,
+        T::Item: AsRef<str>;
+}
+
+/// A price backend that caches the price data in a local database
+///
+/// The cache is used to reduce the number of requests to the source and to improve the performance.
+///
+/// **Note:** depending on the configuration, this backend may be used to return the last saved price
+/// data even if the source is unavailable, which may lead to incorrect price data.
+#[derive(Debug, Clone, typed_builder::TypedBuilder)]
+pub struct CachedPriceBackend<B, S> {
+    /// The price backend
+    backend: B,
+    /// The local data store used for caching
+    store: S,
+    /// The cache expiration time in seconds
+    /// If the cache is older than this value, it will be refreshed
+    /// If the value is `None`, the cache will never expire
+    /// The default value is `15 minutes`.
+    #[builder(default = Some(Duration::from_secs(15 * 60)), setter(strip_option))]
+    cache_expiration: Option<Duration>,
+    /// Specifies whether the cache should be returned even if the source is unavailable
+    ///
+    /// If the value is `true`, the cache will be returned even if the source
+    /// backend is unavailable even if the cache is expired.
+    #[builder(setter(strip_bool))]
+    use_cache_if_source_unavailable: bool,
+}
+
+/// A cached price data
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct CachedPrice {
+    /// The Cached Price of the token
+    pub price: f64,
+    /// The timestamp of the cached price
+    pub timestamp: i64,
+}
+
+impl<B, S> CachedPriceBackend<B, S>
+where
+    B: PriceBackend,
+    S: TokenPriceCacheStore<CachedPrice>,
+{
+    /// Returns the cache expiration duration
+    pub const fn cache_expiration(&self) -> Option<Duration> {
+        self.cache_expiration
+    }
+
+    /// Returns `true` if the cache should be returned even if the source is unavailable
+    pub const fn use_cache_if_source_unavailable_enabled(&self) -> bool {
+        self.use_cache_if_source_unavailable
+    }
+
+    /// Returns the inner price backend
+    pub const fn inner(&self) -> &B {
+        &self.backend
+    }
+
+    /// Returns the inner data store
+    /// The data store is used for caching the price data
+    pub const fn store(&self) -> &S {
+        &self.store
+    }
+}
+
+#[async_trait::async_trait]
+impl<B, S> PriceBackend for CachedPriceBackend<B, S>
+where
+    B: PriceBackend + Clone + Send + Sync + 'static,
+    S: TokenPriceCacheStore<CachedPrice> + Clone + Send + Sync + 'static,
+{
+    async fn get_prices_vs_currency<T>(
+        &self,
+        tokens: T,
+        vs_currency: FiatCurrency,
+    ) -> Result<PricesMap>
+    where
+        T: IntoIterator + Send + Sync,
+        T::Item: AsRef<str>,
+    {
+        // The returned prices map
+        let mut prices = PricesMap::new();
+        // The tokens that need to be fetched from the source
+        let mut tokens_to_fetch = HashSet::new();
+
+        for token in tokens {
+            let token_key = format!("{}/{}", token.as_ref(), vs_currency);
+            // Check if the token is cached
+            if let Some(cached) = self.store.get_price(&token_key)? {
+                let expired = self
+                    .cache_expiration
+                    .map(|expiration| {
+                        let ts = NaiveDateTime::from_timestamp_opt(
+                            cached.timestamp + expiration.as_secs() as i64,
+                            Default::default(),
+                        )
+                        .expect("Time went backwards");
+                        DateTime::<Utc>::from_utc(ts, Utc) < Utc::now()
+                    })
+                    .unwrap_or(false);
+                // If the cache is expired, add the token to the list of tokens to fetch
+                if expired {
+                    tokens_to_fetch.insert(token.as_ref().to_owned());
+                } else {
+                    prices.insert(token_key, cached.price);
+                }
+            } else {
+                // If the token is not cached, add it to the list of tokens to fetch
+                tokens_to_fetch.insert(token.as_ref().to_owned());
+            }
+        }
+        if !tokens_to_fetch.is_empty() {
+            // Fetch the prices from the source
+            let result = self
+                .backend
+                .get_prices_vs_currency(&tokens_to_fetch, vs_currency)
+                .await;
+            let updated_prices = match result {
+                Ok(updated_prices) => updated_prices,
+                Err(err) => {
+                    // If the source is unavailable and the cache is enabled, return the cache
+                    if self.use_cache_if_source_unavailable {
+                        PricesMap::new()
+                    } else {
+                        return Err(err);
+                    }
+                }
+            };
+
+            // Update the cache
+            for (token, price) in updated_prices {
+                let token_key = format!("{}/{}", token, vs_currency);
+                prices.insert(token_key.clone(), price);
+                self.store.insert_price(
+                    &token_key,
+                    CachedPrice {
+                        price,
+                        timestamp: Utc::now().timestamp(),
+                    },
+                )?;
+            }
+        }
+        Ok(prices)
+    }
+}

--- a/crates/price-oracle-backends/src/merger.rs
+++ b/crates/price-oracle-backends/src/merger.rs
@@ -1,0 +1,87 @@
+use webb_relayer_utils::Result;
+
+/// A Price Oracle Merger backend is a backend that builds on top of other backends and merges the
+/// price data from the underlying backends. The merger backend is useful when you want to use
+/// multiple backends to fetch the price data and merge the results. For example, you can use the
+/// `CoinGecko` backend to fetch the price data and the `CoinMarketCap` backend to fetch the price
+/// data for the tokens that are not supported by the `CoinGecko` backend.
+///
+/// ## Semantics
+///
+/// The merger backend will fetch the price data from the underlying backends and merge the results,
+/// the following rules are applied:
+/// - If the price data is available in all backends, the price data from the **last** merged backend is used.
+/// - If the price is not available in any of the backends, the price data is not included in the result.
+#[allow(clippy::module_name_repetitions)]
+pub struct PriceOracleMerger {
+    /// The underlying backends
+    backends: Vec<Box<dyn super::PriceBackend>>,
+}
+
+impl PriceOracleMerger {
+    /// Creates a new `PriceOracleMergerBuilder`
+    #[must_use]
+    pub fn builder() -> PriceOracleMergerBuilder {
+        PriceOracleMergerBuilder {
+            backends: Vec::default(),
+        }
+    }
+}
+
+/// A builder for the `PriceOracleMerger`
+pub struct PriceOracleMergerBuilder {
+    backends: Vec<Box<dyn super::PriceBackend>>,
+}
+
+impl PriceOracleMergerBuilder {
+    /// Merges the price data from the underlying backends
+    ///
+    /// The price data is merged according to the following rules:
+    /// - If the price data is available in all backends, the price data from the **last** merged backend is used.
+    /// - If the price is not available in any of the backends, the price data is not included in the result.
+    #[must_use]
+    pub fn merge(mut self, backend: Box<dyn super::PriceBackend>) -> Self {
+        self.backends.push(backend);
+        self
+    }
+
+    /// Builds the `PriceOracleMerger`
+    #[must_use]
+    pub fn build(self) -> PriceOracleMerger {
+        PriceOracleMerger {
+            backends: self.backends,
+        }
+    }
+}
+
+impl PriceOracleMerger {
+    /// Merges the price data from the underlying backends
+    ///
+    /// The price data is merged according to the following rules:
+    /// - If the price data is available in all backends, the price data from the **last** merged backend is used.
+    /// - If the price is not available in any of the backends, the price data is not included in the result.
+    pub fn merge(
+        &mut self,
+        backend: Box<dyn super::PriceBackend>,
+    ) -> &mut Self {
+        self.backends.push(backend);
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl super::PriceBackend for PriceOracleMerger {
+    async fn get_prices_vs_currency(
+        &self,
+        tokens: &[&str],
+        currency: super::FiatCurrency,
+    ) -> Result<super::PricesMap> {
+        let mut prices = super::PricesMap::new();
+        for backend in &self.backends {
+            let backend_prices =
+                backend.get_prices_vs_currency(tokens, currency).await?;
+            prices.extend(backend_prices);
+        }
+        Ok(prices)
+    }
+}

--- a/crates/proposal-signing-backends/src/mocked.rs
+++ b/crates/proposal-signing-backends/src/mocked.rs
@@ -35,7 +35,7 @@ where
         &self,
         chain_id: TypedChainId,
     ) -> webb_relayer_utils::Result<LocalWallet> {
-        let key = SecretKey::from_be_bytes(self.private_key.as_bytes())?;
+        let key = SecretKey::from_bytes(self.private_key.as_bytes().into())?;
         let signer = LocalWallet::from(key)
             .with_chain_id(chain_id.underlying_chain_id());
         Ok(signer)
@@ -68,7 +68,7 @@ where
         let signer = self.signer(dest_chain_id)?;
         let proposal_bytes = proposal.to_vec();
         let hash = keccak256(&proposal_bytes);
-        let signature = signer.sign_hash(TxHash(hash));
+        let signature = signer.sign_hash(TxHash(hash))?;
         let bridge_key = BridgeKey::new(dest_chain_id);
         tracing::debug!(
             %bridge_key,

--- a/crates/relayer-context/Cargo.toml
+++ b/crates/relayer-context/Cargo.toml
@@ -11,8 +11,8 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-relayer-config = { path = "../relayer-config"}
-webb-relayer-utils = { path = "../relayer-utils"}
+webb-relayer-config = { path = "../relayer-config" }
+webb-relayer-utils = { path = "../relayer-utils" }
 webb-relayer-store = { path = "../relayer-store" }
 
 tokio = { workspace = true }
@@ -21,8 +21,6 @@ sp-core = { workspace = true }
 # Used by ethers (but we need it to be vendored with the lib).
 native-tls = { workspace = true }
 
-coingecko = "1.0.1"
-ethers = {version = "1.0.2", features = ["rustls"] }
 
 [features]
 default = ["std", "evm", "substrate"]

--- a/crates/relayer-context/Cargo.toml
+++ b/crates/relayer-context/Cargo.toml
@@ -11,9 +11,10 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webb-relayer-config = { path = "../relayer-config" }
-webb-relayer-utils = { path = "../relayer-utils" }
-webb-relayer-store = { path = "../relayer-store" }
+webb-relayer-config = { workspace = true }
+webb-relayer-utils = { workspace = true }
+webb-relayer-store = { workspace = true }
+webb-price-oracle-backends = { workspace = true, features = ["coingecko"] }
 
 tokio = { workspace = true }
 webb = { workspace = true }

--- a/crates/relayer-context/src/lib.rs
+++ b/crates/relayer-context/src/lib.rs
@@ -33,8 +33,7 @@ use sp_core::sr25519::Pair as Sr25519Pair;
 use webb::substrate::subxt;
 
 use webb_price_oracle_backends::{
-    CachedPriceBackend, CoinGeckoBackend, DummyPriceBackend, PriceBackend,
-    PriceOracleMerger,
+    CachedPriceBackend, CoinGeckoBackend, DummyPriceBackend, PriceOracleMerger,
 };
 use webb_relayer_store::SledStore;
 use webb_relayer_utils::metric::{self, Metrics};
@@ -79,15 +78,15 @@ impl RelayerContext {
                 .collect();
             DummyPriceBackend::new(price_map)
         };
-        let coin_gecko_backend = CoinGeckoBackend::default();
+        let coin_gecko_backend = CoinGeckoBackend::builder().build();
         let cached_backend = CachedPriceBackend::builder()
             .backend(coin_gecko_backend)
             .store(store.clone())
             .use_cache_if_source_unavailable()
             .build();
         let price_oracle = PriceOracleMerger::builder()
-            .merge(Box::new(dummy_backend))
             .merge(Box::new(cached_backend))
+            .merge(Box::new(dummy_backend))
             .build();
         let price_oracle = Arc::new(price_oracle);
         let mut etherscan_clients: HashMap<u32, Client> = HashMap::new();
@@ -209,6 +208,7 @@ impl RelayerContext {
         &self.store
     }
 
+    /// Returns a price oracle for fetching token prices.
     pub fn price_oracle(&self) -> Arc<PriceOracleMerger> {
         self.price_oracle.clone()
     }

--- a/crates/relayer-context/src/lib.rs
+++ b/crates/relayer-context/src/lib.rs
@@ -78,14 +78,16 @@ impl RelayerContext {
                 .collect();
             DummyPriceBackend::new(price_map)
         };
-        let coin_gecko_backend = CoinGeckoBackend::builder().build();
-        let cached_backend = CachedPriceBackend::builder()
-            .backend(coin_gecko_backend)
+        // **chef's kiss** this is so beautiful
+        let cached_coingecko_backend = CachedPriceBackend::builder()
+            .backend(CoinGeckoBackend::builder().build())
             .store(store.clone())
             .use_cache_if_source_unavailable()
+            .even_if_expired()
             .build();
+        // merge all the price oracle backends
         let price_oracle = PriceOracleMerger::builder()
-            .merge(Box::new(cached_backend))
+            .merge(Box::new(cached_coingecko_backend))
             .merge(Box::new(dummy_backend))
             .build();
         let price_oracle = Arc::new(price_oracle);

--- a/crates/relayer-handlers/src/routes/info.rs
+++ b/crates/relayer-handlers/src/routes/info.rs
@@ -36,7 +36,7 @@ pub async fn handle_relayer_info(
                 .private_key
                 .as_ref()
                 .ok_or(webb_relayer_utils::Error::MissingSecrets)?;
-            let key = SecretKey::from_be_bytes(key.as_bytes())?;
+            let key = SecretKey::from_bytes(key.as_bytes().into())?;
             let wallet = LocalWallet::from(key);
             v.beneficiary = Some(wallet.address());
             webb_relayer_utils::Result::Ok(())

--- a/crates/relayer-store/src/lib.rs
+++ b/crates/relayer-store/src/lib.rs
@@ -32,9 +32,11 @@ use webb_relayer_utils::Result;
 /// A module for managing in-memory storage of the relayer.
 pub mod mem;
 /// A module for setting up and managing a [Sled](https://sled.rs)-based database.
+#[cfg(feature = "sled")]
 pub mod sled;
 
 /// A store that uses [`sled`](https://sled.rs) as the backend.
+#[cfg(feature = "sled")]
 pub use self::sled::SledStore;
 /// A store that uses in memory data structures as the backend.
 pub use mem::InMemoryStore;
@@ -424,4 +426,25 @@ pub trait ProposalStore {
         &self,
         data_hash: &[u8],
     ) -> crate::Result<Option<Self::Proposal>>;
+}
+
+/// A trait for Cached Token Price.
+pub trait TokenPriceCacheStore<CachedTokenPrice>
+where
+    CachedTokenPrice: Serialize + DeserializeOwned,
+{
+    /// Get the cached token price for the given token key.
+    /// If the token is not found, it will return `None`.
+    fn get_price(
+        &self,
+        token_key: &str,
+    ) -> crate::Result<Option<CachedTokenPrice>>;
+    /// Insert the cached token price for the given token key.
+    ///
+    /// **Note**: this will override the previous value.
+    fn insert_price(
+        &self,
+        token_key: &str,
+        value: CachedTokenPrice,
+    ) -> crate::Result<()>;
 }

--- a/crates/relayer-utils/Cargo.toml
+++ b/crates/relayer-utils/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+thiserror = { workspace = true }
 hex = { workspace = true }
 backoff = { workspace = true }
 serde_path_to_error = { workspace = true }
@@ -28,7 +29,6 @@ config = { workspace = true }
 ark-std = { version = "^0.3.0", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["display"] }
 prometheus = "0.13.3"
-thiserror = "^1"
 reqwest = "0.11"
 hyper = "0.14.24"
 

--- a/crates/tx-relay/Cargo.toml
+++ b/crates/tx-relay/Cargo.toml
@@ -15,6 +15,7 @@ webb-relayer-handler-utils = { workspace = true }
 webb-relayer-config = { workspace = true }
 webb-relayer-context = { workspace = true }
 webb-relayer-utils = { workspace = true }
+webb-price-oracle-backends = { workspace = true }
 
 tracing = { workspace = true }
 futures = { workspace = true }

--- a/crates/tx-relay/Cargo.toml
+++ b/crates/tx-relay/Cargo.toml
@@ -27,14 +27,10 @@ ethereum-types = { workspace = true }
 serde = { workspace = true }
 
 once_cell = "1.17.0"
-chrono = {version = "0.4.23", features = ["serde"] }
+chrono = { version = "0.4.23", features = ["serde"] }
 
 [features]
 default = ["std", "evm", "substrate"]
 std = []
-evm = [
-    "webb-relayer-context/evm",
-]
-substrate = [
-    "webb-relayer-context/substrate",
-]
+evm = ["webb-relayer-context/evm"]
+substrate = ["webb-relayer-context/substrate"]

--- a/crates/tx-relay/src/evm/fees.rs
+++ b/crates/tx-relay/src/evm/fees.rs
@@ -12,6 +12,7 @@ use webb::evm::contract::protocol_solidity::{
 use webb::evm::ethers::prelude::U256;
 use webb::evm::ethers::types::Address;
 use webb::evm::ethers::utils::{format_units, parse_units};
+use webb_price_oracle_backends::PriceBackend;
 use webb_proposals::TypedChainId;
 use webb_relayer_context::RelayerContext;
 use webb_relayer_utils::Result;
@@ -118,41 +119,29 @@ async fn generate_fee_info(
     let (wrapped_token, wrapped_token_decimals) =
         get_wrapped_token_name_and_decimals(chain_id, vanchor, ctx).await?;
 
-    // Fetch USD prices for tokens from coingecko API (eg value of 1 ETH in USD).
+    // Fetch USD prices for tokens from the price oracle backend (eg value of 1 ETH in USD).
     let prices = ctx
-        .coin_gecko_client()
-        .price(
-            &[native_token, &wrapped_token],
-            &["usd"],
-            false,
-            false,
-            false,
-            false,
-        )
+        .price_oracle()
+        .get_prices(&[native_token, &wrapped_token])
         .await?;
+
     let native_token_price = match prices.get(native_token) {
-        Some(price) => price.usd.expect("price.usd is not None"),
+        Some(price) => *price,
         None => {
             return Err(webb_relayer_utils::Error::FetchTokenPriceError {
                 token: native_token.into(),
             })
         }
     };
-    // try to get wrapped token price from coingecko, if not found, use the price from config
-    // if not found in config, return error
-    let maybe_wrapped_token_price = prices
-        .get(&wrapped_token)
-        .and_then(|p| p.usd)
-        .or(ctx.config.assets.get(&wrapped_token).map(|a| a.price));
-
-    let wrapped_token_price = match maybe_wrapped_token_price {
-        Some(price) => price,
+    let wrapped_token_price = match prices.get(&wrapped_token) {
+        Some(price) => *price,
         None => {
             return Err(webb_relayer_utils::Error::FetchTokenPriceError {
                 token: wrapped_token.clone(),
             })
         }
     };
+
     // Fetch native gas price estimate from etherscan.io, using "average" value
     let gas_oracle = ctx
         .etherscan_client(chain_id.underlying_chain_id())?


### PR DESCRIPTION
## Summary of changes
- Added Price Oracle Backend trait
- Implemented Coingecko as a backend
- Added a CachedPriceOracle backend that would work with any price oracle
- Added a DummyPriceOracle backend that would work with hardcoded prices (e.g for unlisted tokens)
- Added a PriceOracleMerger backend that merges more than one price oracle backend(s) into one!
- Update the hardcoded chain ids (should be resolved and will no need for hardcoding them after #412 )


### Reference issue to close (if applicable)
- Closes #402 

-----
### Code Checklist 

- [x] Tested
- [x] Documented
