### PR TITLE
feat: Improve the `GasOracle` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "coins-bip39"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb68f3b6c3fee83828ecd8d463f360a397c32aaeb35bd931c01e5ddf5631c69"
+checksum = "ad2a68a46b9d8cc90484f0689adc0e4c890eb215bf698ae52e5235bb88f40be7"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+checksum = "19c5cb402c5c958281c7c0702edea7b780d03b86b606497ca3a10fcd3fc393ac"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1654,6 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1754,14 +1755,15 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
+checksum = "a64d2e9c561b39b2de83c0387baffecfbc62ad116c4fc8f4e5b040b8e0737d7c"
 dependencies = [
- "der 0.7.1",
- "elliptic-curve 0.13.2",
+ "der 0.7.2",
+ "digest 0.10.6",
+ "elliptic-curve 0.13.3",
  "rfc6979 0.4.0",
- "signature 2.0.0",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -1828,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+checksum = "22cdacd4d6ed3f9b98680b679c0e52a823b8a2c7a97358d508fe247f2180c282"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.1",
@@ -1838,7 +1840,7 @@ dependencies = [
  "ff 0.13.0",
  "generic-array 0.14.7",
  "group 0.13.0",
- "pkcs8 0.10.1",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.1",
  "subtle",
@@ -1987,7 +1989,7 @@ dependencies = [
  "tokio 1.27.0",
  "toml 0.5.11",
  "tree_hash 0.4.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.21",
  "webb-proposals",
  "webb-relayer-types 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
  "webb-relayer-utils 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
@@ -2134,7 +2136,7 @@ dependencies = [
  "tree_hash 0.4.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
  "types",
  "warp",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.21",
  "webb-proposals",
  "webb-relayer-utils 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
 ]
@@ -2268,16 +2270,16 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
- "ethers-addressbook 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-contract 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-middleware 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-signers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-solc 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-addressbook 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-contract 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-middleware 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-providers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-signers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-solc 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
 ]
 
 [[package]]
@@ -2295,9 +2297,9 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "once_cell",
  "serde",
  "serde_json",
@@ -2325,12 +2327,12 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
- "ethers-contract-abigen 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-contract-derive 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-contract-derive 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-providers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "futures-util",
  "hex",
  "once_cell",
@@ -2370,12 +2372,12 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
  "Inflector",
  "dunce",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "eyre",
  "getrandom 0.2.8",
  "hex",
@@ -2410,10 +2412,10 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
- "ethers-contract-abigen 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "hex",
  "proc-macro2",
  "quote",
@@ -2431,7 +2433,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "convert_case 0.6.0",
- "elliptic-curve 0.13.2",
+ "elliptic-curve 0.13.3",
  "ethabi",
  "generic-array 0.14.7",
  "getrandom 0.2.8",
@@ -2456,14 +2458,14 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.4.0",
  "cargo_metadata",
  "chrono",
  "convert_case 0.6.0",
- "elliptic-curve 0.13.2",
+ "elliptic-curve 0.13.3",
  "ethabi",
  "generic-array 0.14.7",
  "getrandom 0.2.8",
@@ -2505,10 +2507,10 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-solc 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-solc 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "getrandom 0.2.8",
  "reqwest",
  "semver 1.0.17",
@@ -2548,15 +2550,15 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-signers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-providers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-signers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "futures-channel",
  "futures-locks",
  "futures-util",
@@ -2610,14 +2612,14 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
  "async-trait",
  "auto_impl",
  "base64 0.21.0",
  "bytes 1.4.0",
  "enr",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -2651,7 +2653,7 @@ dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve 0.13.2",
+ "elliptic-curve 0.13.3",
  "eth-keystore",
  "ethers-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
@@ -2664,14 +2666,14 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve 0.13.2",
+ "elliptic-curve 0.13.3",
  "eth-keystore",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -2713,11 +2715,11 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.2"
-source = "git+https://github.com/gakonst/ethers-rs#d80e82a561ff714d1fa10c05786bb6fe124edbf0"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
- "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "getrandom 0.2.8",
  "glob",
  "hex",
@@ -3665,13 +3667,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3839,11 +3841,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955890845095ccf31ef83ad41a05aabb4d8cc23dc3cac5a9f5c89cf26dd0da75"
 dependencies = [
  "cfg-if 1.0.0",
- "ecdsa 0.16.2",
- "elliptic-curve 0.13.2",
+ "ecdsa 0.16.3",
+ "elliptic-curve 0.13.3",
  "once_cell",
  "sha2 0.10.6",
- "signature 2.0.0",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -4876,12 +4878,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.1",
- "spki 0.7.0",
+ "der 0.7.2",
+ "spki 0.7.1",
 ]
 
 [[package]]
@@ -5712,9 +5714,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.1",
+ "der 0.7.2",
  "generic-array 0.14.7",
- "pkcs8 0.10.1",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6035,9 +6037,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",
@@ -6494,12 +6496,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
- "der 0.7.1",
+ "der 0.7.2",
 ]
 
 [[package]]
@@ -7940,15 +7942,18 @@ dependencies = [
 
 [[package]]
 name = "webb"
-version = "0.5.21"
-source = "git+https://github.com/webb-tools/webb-rs#1ed2db6eaf930f94774af0293ac751707af825b0"
+version = "0.5.22"
+source = "git+https://github.com/webb-tools/webb-rs#e7f3cdcfcffcc3f4191749fa0ce0eb0d6f3b363d"
 dependencies = [
  "async-trait",
- "ethers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "hex",
+ "parity-scale-codec",
  "rand 0.8.5",
+ "scale-info",
  "serde",
  "serde_json",
+ "subxt",
  "tempfile",
  "thiserror",
 ]
@@ -7968,7 +7973,7 @@ dependencies = [
  "tempfile",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-relayer",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -7989,7 +7994,7 @@ dependencies = [
  "sp-core",
  "tokio 1.27.0",
  "typed-builder 0.12.0",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-utils 0.1.0",
@@ -8007,7 +8012,7 @@ dependencies = [
  "tokio 1.27.0",
  "tracing",
  "tracing-test",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -8026,7 +8031,7 @@ dependencies = [
  "sled",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-event-watcher-traits",
  "webb-proposals",
  "webb-relayer-config",
@@ -8053,7 +8058,7 @@ dependencies = [
  "sled",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-bridge-registry-backends",
  "webb-event-watcher-traits",
  "webb-proposal-signing-backends",
@@ -8075,7 +8080,7 @@ dependencies = [
  "sp-core",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-event-watcher-traits",
  "webb-proposal-signing-backends",
  "webb-proposals",
@@ -8108,7 +8113,7 @@ dependencies = [
  "thiserror",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (git+https://github.com/webb-tools/webb-rs)",
+ "webb 0.5.22",
  "webb-proposal-signing-backends",
  "webb-proposals",
  "webb-relayer",
@@ -8136,7 +8141,7 @@ dependencies = [
  "serde",
  "tokio 1.27.0",
  "typed-builder 0.12.0",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-relayer-store",
  "webb-relayer-utils 0.1.0",
 ]
@@ -8155,7 +8160,7 @@ dependencies = [
  "tokio 1.27.0",
  "tracing",
  "typed-builder 0.12.0",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
  "webb-relayer-store",
  "webb-relayer-types 0.1.0",
@@ -8198,7 +8203,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-bridge-registry-backends",
  "webb-event-watcher-traits",
  "webb-ew-dkg",
@@ -8234,7 +8239,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.16",
  "url",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
  "webb-relayer-store",
  "webb-relayer-types 0.1.0",
@@ -8248,7 +8253,7 @@ dependencies = [
  "native-tls",
  "sp-core",
  "tokio 1.27.0",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-price-oracle-backends",
  "webb-relayer-config",
  "webb-relayer-store",
@@ -8262,7 +8267,7 @@ dependencies = [
  "native-tls",
  "serde",
  "tokio 1.27.0",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-relayer-tx-relay-utils",
 ]
 
@@ -8281,7 +8286,7 @@ dependencies = [
  "tokio 1.27.0",
  "tokio-stream",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-context",
@@ -8303,7 +8308,7 @@ dependencies = [
  "sled",
  "tempfile",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
  "webb-relayer-utils 0.1.0",
 ]
@@ -8322,7 +8327,7 @@ dependencies = [
  "sp-runtime",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-relayer-context",
  "webb-relayer-store",
  "webb-relayer-types 0.1.0",
@@ -8341,7 +8346,7 @@ dependencies = [
  "serde",
  "tokio 1.27.0",
  "tracing",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-price-oracle-backends",
  "webb-proposals",
  "webb-relayer-config",
@@ -8369,7 +8374,7 @@ dependencies = [
  "tiny-bip39",
  "tracing",
  "url",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
 ]
 
 [[package]]
@@ -8384,7 +8389,7 @@ dependencies = [
  "tiny-bip39",
  "tracing",
  "url",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.21",
 ]
 
 [[package]]
@@ -8408,7 +8413,7 @@ dependencies = [
  "sled",
  "thiserror",
  "url",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.22",
  "webb-proposals",
 ]
 
@@ -8433,7 +8438,7 @@ dependencies = [
  "sled",
  "thiserror",
  "url",
- "webb 0.5.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webb 0.5.21",
  "webb-proposals",
 ]
 
@@ -8541,6 +8546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "ethers-addressbook 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-contract 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "once_cell",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-contract-derive 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2372,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "Inflector",
  "dunce",
@@ -2412,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.4.0",
@@ -2507,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-solc 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2666,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#4cca52f014b554b804bde9a6b87f3c5a8857665d"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "ethers-addressbook 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-contract 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "once_cell",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-contract-derive 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2372,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "Inflector",
  "dunce",
@@ -2412,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.4.0",
@@ -2507,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
  "ethers-solc 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2612,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2666,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#76b3f1e20fc77d38c4457147316f8acfcb2019ec"
+source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
@@ -7395,7 +7395,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.6",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,16 +2270,16 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
- "ethers-addressbook 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-contract 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-etherscan 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-middleware 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-providers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-signers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-solc 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-addressbook 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
 ]
 
 [[package]]
@@ -2297,9 +2297,9 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "once_cell",
  "serde",
  "serde_json",
@@ -2327,12 +2327,12 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
- "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-contract-derive 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-providers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-contract-abigen 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-derive 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "futures-util",
  "hex",
  "once_cell",
@@ -2372,12 +2372,12 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
  "Inflector",
  "dunce",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-etherscan 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "eyre",
  "getrandom 0.2.8",
  "hex",
@@ -2412,10 +2412,10 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
- "ethers-contract-abigen 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-contract-abigen 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "hex",
  "proc-macro2",
  "quote",
@@ -2458,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.4.0",
@@ -2507,10 +2507,10 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-solc 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "getrandom 0.2.8",
  "reqwest",
  "semver 1.0.17",
@@ -2550,15 +2550,15 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-etherscan 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-providers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
- "ethers-signers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-contract 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "futures-channel",
  "futures-locks",
  "futures-util",
@@ -2612,14 +2612,14 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
  "async-trait",
  "auto_impl",
  "base64 0.21.0",
  "bytes 1.4.0",
  "enr",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -2666,14 +2666,14 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
  "elliptic-curve 0.13.3",
  "eth-keystore",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -2715,11 +2715,11 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "2.0.2"
-source = "git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response#789f449385ade3269bdab5f86301d64c4ee91f3f"
+source = "git+https://github.com/gakonst/ethers-rs#1dd35458695e2b967d4c2ff278cc8d0eaadcc9fb"
 dependencies = [
  "cfg-if 1.0.0",
  "dunce",
- "ethers-core 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers-core 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "getrandom 0.2.8",
  "glob",
  "hex",
@@ -7395,7 +7395,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.6",
  "rand 0.8.5",
  "static_assertions",
@@ -7943,10 +7943,10 @@ dependencies = [
 [[package]]
 name = "webb"
 version = "0.5.22"
-source = "git+https://github.com/webb-tools/webb-rs#e7f3cdcfcffcc3f4191749fa0ce0eb0d6f3b363d"
+source = "git+https://github.com/webb-tools/webb-rs#ce757c52c404c4ebe1499712429ca858bff200f0"
 dependencies = [
  "async-trait",
- "ethers 2.0.2 (git+https://github.com/shekohex/ethers-rs?branch=shekohex/etherscan-gasoracle-response)",
+ "ethers 2.0.2 (git+https://github.com/gakonst/ethers-rs)",
  "hex",
  "parity-scale-codec",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,8 @@ tokio = { version = "^1", features = ["full"] }
 config = { version = "0.13", default-features = false, features = ["toml", "json"] }
 serde_json = { version = "^1", default-features = false }
 paw = { version = "^1.0" }
-webb = { version = "0.5.21", default-features = false }
+# webb = { version = "0.5.21", default-features = false }
+webb = { version = "0.5.22", git = "https://github.com/webb-tools/webb-rs", default-features = false }
 sp-core = { version = "16.0.0", default-features = false }
 sp-runtime = { version = "18.0.0", default-features = false }
 # Used by ethers (but we need it to be vendored with the lib).

--- a/crates/relayer-config/src/lib.rs
+++ b/crates/relayer-config/src/lib.rs
@@ -175,6 +175,12 @@ pub struct EtherscanApiConfig {
     /// A wrapper type around the `String` to allow reading it from the env.
     #[serde(skip_serializing)]
     pub api_key: EtherscanApiKey,
+    /// An optional URL to use for the Etherscan API instead of the default.
+    ///
+    /// This is useful for testing against a local Etherscan API.
+    /// Or in case of testnets, the Etherscan GasOracle API is not available.
+    /// So we can use the mainnet API URL to get the gas price.
+    pub api_url: Option<url::Url>,
 }
 
 /// TxQueueConfig is the configuration for the TxQueue.

--- a/crates/relayer-utils/src/lib.rs
+++ b/crates/relayer-utils/src/lib.rs
@@ -105,6 +105,8 @@ pub enum Error {
     /// Etherscan API error
     #[error(transparent)]
     Etherscan(#[from] ethers::etherscan::errors::EtherscanError),
+    #[error(transparent)]
+    GasOracle(#[from] ethers::middleware::gas_oracle::GasOracleError),
     /// Ether wallet errors.
     #[error(transparent)]
     EtherWalletError(#[from] ethers::signers::WalletError),

--- a/crates/tx-relay/src/evm/fees.rs
+++ b/crates/tx-relay/src/evm/fees.rs
@@ -25,9 +25,6 @@ static FEE_CACHE_TIME: Lazy<Duration> = Lazy::new(|| Duration::minutes(1));
 /// Amount of profit that the relay should make with each transaction (in USD).
 const TRANSACTION_PROFIT_USD: f64 = 5.;
 
-const GWEI_TO_WEI: u64 = 1_000_000_000;
-const GWEI_TO_WEI_U256: U256 = U256([GWEI_TO_WEI, 0, 0, 0]);
-
 /// Cache for previously generated fee info. Key consists of the VAnchor address and chain id.
 /// Entries are valid as long as `timestamp` is no older than `FEE_CACHE_TIME`.
 static FEE_INFO_CACHED: Lazy<Mutex<HashMap<(Address, TypedChainId), FeeInfo>>> =

--- a/services/light-client-relayer/Cargo.toml
+++ b/services/light-client-relayer/Cargo.toml
@@ -39,7 +39,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 tokio = { version = "^1", features = ["full"] }
 serde_json = { version = "^1", default-features = false }
 paw = { version = "^1.0", optional = true }
-webb = { git = "https://github.com/webb-tools/webb-rs" , default-features = false, features = ["evm-runtime"] }
+webb = { workspace = true, default-features = false, features = ["evm-runtime"] }
 webb-proposals = { version = "0.5.4", default-features = false, features = ["scale", "evm", "substrate"] }
 # Used by ethers (but we need it to be vendored with the lib).
 native-tls = { version = "^0.2", features = ["vendored"], optional = true }


### PR DESCRIPTION
## Summary of changes
- Add a new option to override the default API Endpoint for Etherscan API configuration (see below for an example)
- Adds a new feature that will use different gas oracle at once and take the median value of all of the succeeded gas oracles in a weighted way. For example, we will query _in parallel_ all configured Gas Oracles and take the median value of all of the responses.
For now, we support the following gas oracles:
1. Native Provider Gas Oracle (a la `eth_gasPrice` RPC) with weight of `0.1` and this the default gas oracle.
2. Etherscan Gas Oracle with weight of `0.9` and it is _optional_ by default.
- Updates webb-rs to reflect the new updates to ethers-rs to the latest commit to fix https://github.com/gakonst/ethers-rs/issues/2324

### Example of the new Configuration options

```toml
[evm-etherscan.polygon_mumbai]
chain-id = 80001
api-key = "$POLYGONSCAN_API_KEY"
# Notice: We override the default API Endpoint
# from https://api-testnet.polygonscan.com/api
# to https://api.polygonscan.com/api
# To use the mainnet API instead of the testnet one
# Since the etherscan testnet's API does not support gas oracles.
api-url = "https://api.polygonscan.com/api"
```


### Reference issue to close (if applicable)
- Depends on https://github.com/webb-tools/webb-rs/pull/131

-----
### Code Checklist 

- [x] Tested
- [x] Documented
