### PR TITLE
Use bridge registry for substrate chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8110,6 +8110,7 @@ dependencies = [
  "tokio 1.27.0",
  "tracing",
  "webb 0.5.22",
+ "webb-bridge-registry-backends",
  "webb-event-watcher-traits",
  "webb-proposal-signing-backends",
  "webb-proposals",

--- a/event-watchers/substrate/Cargo.toml
+++ b/event-watchers/substrate/Cargo.toml
@@ -12,6 +12,7 @@ repository = { workspace = true }
 
 [dependencies]
 webb-proposal-signing-backends = { workspace = true }
+webb-bridge-registry-backends = { workspace = true }
 webb-event-watcher-traits = { workspace = true }
 webb-relayer-types = { workspace = true }
 webb-relayer-store = { workspace = true }

--- a/services/webb-relayer/src/service/substrate.rs
+++ b/services/webb-relayer/src/service/substrate.rs
@@ -5,6 +5,8 @@ use axum::Router;
 use sp_core::sr25519;
 use webb::substrate::subxt::config::ExtrinsicParams;
 use webb::substrate::subxt::{self, PolkadotConfig};
+use webb_bridge_registry_backends::dkg::DkgBridgeRegistryBackend;
+use webb_bridge_registry_backends::mocked::MockedBridgeRegistryBackend;
 use webb_event_watcher_traits::{
     SubstrateBridgeWatcher, SubstrateEventWatcher,
 };
@@ -361,12 +363,13 @@ pub fn start_substrate_vanchor_event_watcher(
         .await?;
         match proposal_signing_backend {
             ProposalSigningBackendSelector::Dkg(backend) => {
-                // its safe to use unwrap on linked_anchors here
-                // since this option is always going to return Some(value).
-                // linked_anchors are validated in make_proposal_signing_backend() method
+                let bridge_registry =
+                    DkgBridgeRegistryBackend::new(backend.client.clone());
+
                 let deposit_handler = SubstrateVAnchorDepositHandler::new(
                     backend,
-                    my_config.linked_anchors.unwrap_or_default(),
+                    bridge_registry,
+                    my_config.linked_anchors,
                 );
                 let leaves_handler = SubstrateVAnchorLeavesHandler::default();
                 let encrypted_output_handler =
@@ -403,11 +406,13 @@ pub fn start_substrate_vanchor_event_watcher(
                 }
             }
             ProposalSigningBackendSelector::Mocked(backend) => {
-                // its safe to use unwrap on linked_anchors here
-                // since this option is always going to return Some(value).
+                let bridge_registry =
+                    MockedBridgeRegistryBackend::builder().build();
+
                 let deposit_handler = SubstrateVAnchorDepositHandler::new(
                     backend,
-                    my_config.linked_anchors.unwrap_or_default(),
+                    bridge_registry,
+                    my_config.linked_anchors,
                 );
                 let leaves_handler = SubstrateVAnchorLeavesHandler::default();
                 let encrypted_output_handler =


### PR DESCRIPTION
## Summary of changes
-  fetch linked anchors from the bridge registry pallet for substrate chains.


### Reference issue to close (if applicable)
- Closes #448 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
