### PR TITLE
Attempt to speedup CI steps (ref #449)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
 
-  macos-build:
+  macos-check:
     runs-on: macos-latest
     steps:
       - name: Cancel Previous Runs
@@ -41,7 +41,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build target
-        run: cargo build --release --target=${{ matrix.target }} --features native-tls/vendored --locked
+        run: cargo check --target=${{ matrix.target }} --features native-tls/vendored --locked
 
     strategy:
       fail-fast: true
@@ -73,8 +73,8 @@ jobs:
         
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-      - name: Build target
-        run: cargo test --release --target=${{ matrix.target }} --locked
+      - name: Check target
+        run: cargo test --target=${{ matrix.target }} --locked
           
     strategy:
       fail-fast: true
@@ -84,7 +84,7 @@ jobs:
           - x86_64-apple-darwin
         
 
-  linux-build:
+  linux-check:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -110,8 +110,8 @@ jobs:
 
       - name: Install cross
         run: cargo install cross --locked
-      - name: Build target using cross
-        run: cross build --release --target=${{ matrix.target }} --features native-tls/vendored --locked
+      - name: Check target using cross
+        run: cross check --target=${{ matrix.target }} --features native-tls/vendored --locked
 
     strategy:
       fail-fast: true
@@ -164,7 +164,7 @@ jobs:
       - name: Install cross
         run: cargo install cross --locked
       - name: Build target using cross
-        run: cross test --release --target=${{ matrix.target }} --features native-tls/vendored --locked
+        run: cross test --target=${{ matrix.target }} --features native-tls/vendored --locked
 
     strategy:
       fail-fast: true
@@ -205,9 +205,6 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
 
         if: matrix.target == 'x86_64-unknown-linux-musl'
-      - run: cargo build --features integration-tests,cli,native-tls/vendored
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        shell: bash
 
       - name: Install NPM Packages.
         if: matrix.target == 'x86_64-unknown-linux-musl'

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -118,7 +118,7 @@ export class WebbRelayer {
         '--bin',
         'webb-relayer',
         '--features',
-        'integration-tests,cli',
+        'integration-tests,cli,native-tls/vendored',
         '--',
         '-c',
         opts.configDir,


### PR DESCRIPTION
## Summary of changes
- Remove unnecessary cargo build step for integration tests
- Use `cargo check` instead of `cargo build`
- Dont run tests in release mode

This reduces the total runtime of tests from [3h 3m](https://github.com/webb-tools/relayer/actions/runs/4657577954/usage) to [1h 41m](https://github.com/webb-tools/relayer/actions/runs/4666652799/usage). As far as I can tell the checks are equivalent in both cases. However it still takes roughly 30m like before to finish all tests, because `linux-integration-tests` is quite slow. We could try to improve this by splitting integration tests in two, then evm and substrate tests could run in parallel which should roughly cut the total time in half.

### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
