### PR TITLE
fix: `u64` overflow when updating relayer metrics

### DIFF
--- a/crates/relayer-utils/src/metric.rs
+++ b/crates/relayer-utils/src/metric.rs
@@ -21,7 +21,7 @@ use webb_proposals::ResourceId;
 /// A struct for collecting metrics for particular resource.
 #[derive(Debug, Clone)]
 pub struct ResourceMetric {
-    /// Total gas spent on Resource.
+    /// Total gas spent (in gwei) on Resource.
     pub total_gas_spent: GenericCounter<AtomicF64>,
     /// Total fees earned on Resource.
     pub total_fee_earned: GenericCounter<AtomicF64>,
@@ -174,7 +174,7 @@ impl Metrics {
         let total_gas_spent_counter = register_counter!(
             format!("resource_{resource_hex}_total_gas_spent"),
             format!(
-                "The total number of gas spent on resource : {resource_hex}"
+                "The total number of gas (in gwei) spent on resource : {resource_hex}"
             )
         );
         // Total fee earned on particular resource.


### PR DESCRIPTION

## Summary of changes
- Properly convert between `U256` and `f64`.
- Send the response back to the client before updating the metrics.
- Update the docs related to the metrics.


### Reference issue to close (if applicable)
- Closes #470 

-----
### Code Checklist 

- [x] Tested
- [x] Documented
