### PR TITLE
Changes to CI conditions, push new commits on develop to `edge` tag

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - main
-      - develop
   pull_request:
     branches:
       - develop

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Publish `main` as Container `edge` image.
     branches:
-      - main
+      - develop
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,8 +1,5 @@
 on:
   push:
-    branches:
-      - main
-      - develop
   pull_request:
     branches:
       - develop

--- a/.github/workflows/publish-rust-docs.yml
+++ b/.github/workflows/publish-rust-docs.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   publish_docs:


### PR DESCRIPTION
## Summary of changes
- Disable lints, integration tests etc on main and develop branches. These are unnecessary because code can only be added through pull request and not pushed directly to those branches.
- `edge` image is currently only built on main branch. Im changing it to develop.


### Reference issue to close (if applicable)
- Ref https://github.com/webb-tools/relayer/issues/449

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
