### PR TITLE
Try using shared key for rust cache to speedup CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,6 +114,11 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+
       - name: Install cross
         run: cargo install cross --locked
       - name: Check target using cross

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
 
       - name: Build target
         run: cargo check --target=${{ matrix.target }} --features native-tls/vendored --locked
@@ -79,7 +79,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
 
       - name: Check target
         run: cargo test --target=${{ matrix.target }} --locked
@@ -120,7 +120,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
 
       - name: Install cross
         run: cargo install cross --locked
@@ -163,7 +163,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -217,7 +217,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/"
 
       - name: Build target
         run: cargo check --target=${{ matrix.target }} --features native-tls/vendored --locked
@@ -78,6 +79,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/"
 
       - name: Check target
         run: cargo test --target=${{ matrix.target }} --locked
@@ -118,6 +120,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/"
 
       - name: Install cross
         run: cargo install cross --locked
@@ -155,6 +158,12 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/"
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -208,6 +217,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/"
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,9 @@ jobs:
         
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+
       - name: Build target
         run: cargo check --target=${{ matrix.target }} --features native-tls/vendored --locked
 
@@ -73,6 +76,9 @@ jobs:
         
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+
       - name: Check target
         run: cargo test --target=${{ matrix.target }} --locked
           
@@ -195,6 +201,8 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,12 +116,6 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/cache"
-
       - name: Install cross
         run: cargo install cross --locked
       - name: Check target using cross
@@ -158,12 +152,6 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust"
-          cache-directories: ".dvc/tmp\n.dvc/cache"
 
       - name: Use Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Summary of changes
- Set `shared-key` for Rust Cache. This decreases Rust built time for integration tests from 8m to 50s. So the cache was really not used before.
- Tried caching `dvc` folders. This decreases duration of "Install NPM packages" (which includes `dvc pull`) from 4m 40s to 2m 50s. It might also help with occasional failures from dvc pull. However it increases cache size from 700 MB to 3.5 GB so the 10 GB limit can store only 3 cache entries instead of 14. Not sure if this is a good idea.
- Tried to add caching for unit test and check commands, but this fails due to usage of `cargo cross`:
    ```
    error: failed to run custom build command for `libc v0.2.141`
    
    Caused by:
      process didn't exit successfully: `/target/debug/build/libc-419af779436d366a/build-script-build` (exit status: 1)
      --- stderr
    /target/debug/build/libc-419af779436d366a/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by /target/debug/build/libc-419af779436d366a/build-script-build)
    /target/debug/build/libc-419af779436d366a/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /target/debug/build/libc-419af779436d366a/build-script-build)
    warning: build failed, waiting for other jobs to finish...
    Error: Process completed with exit code 101.
    ```
    [Upstream issue is here](https://github.com/Swatinem/rust-cache/issues/42). Anyway these jobs are fast enough with around 10m so its probably fine without caching.  

### Reference issue to close (if applicable)
- Closes 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
