### PR TITLE
fix: Add RetryClient to the EVM Providers

### DIFF
--- a/crates/event-watcher-traits/src/evm/bridge_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/bridge_watcher.rs
@@ -50,7 +50,7 @@ where
     )]
     async fn run(
         &self,
-        client: Arc<providers::Provider<providers::Http>>,
+        client: Arc<EthersClient>,
         store: Arc<Self::Store>,
         contract: Self::Contract,
         metrics: Arc<Mutex<metric::Metrics>>,

--- a/crates/event-watcher-traits/src/evm/event_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/event_watcher.rs
@@ -17,6 +17,10 @@ use webb_relayer_utils::retry;
 
 use super::*;
 
+/// Ethereum client using Ethers, that includes a retry strategy.
+pub type EthersClient =
+    providers::Provider<providers::RetryClient<providers::Http>>;
+
 /// A watchable contract is a contract used in the [EventWatcher]
 pub trait WatchableContract: Send + Sync {
     /// The block number where this contract is deployed.
@@ -49,7 +53,7 @@ pub trait EventWatcher {
     /// A Helper tag used to identify the event watcher during the logs.
     const TAG: &'static str;
     /// The contract that this event watcher is watching.
-    type Contract: Deref<Target = contract::Contract<providers::Provider<providers::Http>>>
+    type Contract: Deref<Target = contract::Contract<EthersClient>>
         + WatchableContract;
     /// The Events that this event watcher is interested in.
     type Events: contract::EthLogDecode + Clone;
@@ -67,7 +71,7 @@ pub trait EventWatcher {
     )]
     async fn run(
         &self,
-        client: Arc<providers::Provider<providers::Http>>,
+        client: Arc<EthersClient>,
         store: Arc<Self::Store>,
         contract: Self::Contract,
         handlers: Vec<EventHandlerFor<Self>>,
@@ -245,7 +249,7 @@ pub trait EventWatcher {
 pub trait EventHandler {
     /// The Type of contract this handler is for, Must be the same as the contract type in the
     /// watcher.
-    type Contract: Deref<Target = contract::Contract<providers::Provider<providers::Http>>>
+    type Contract: Deref<Target = contract::Contract<EthersClient>>
         + WatchableContract;
     /// The type of event this handler is for.
     type Events: contract::EthLogDecode + Clone;

--- a/crates/relayer-context/src/lib.rs
+++ b/crates/relayer-context/src/lib.rs
@@ -16,9 +16,9 @@
 //! # Relayer Context Module 🕸️
 //!
 //! A module for managing the context of the relayer.
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{collections::HashMap, convert::TryFrom};
 
 use tokio::sync::{broadcast, Mutex};
 
@@ -135,15 +135,18 @@ impl RelayerContext {
     pub async fn evm_provider(
         &self,
         chain_id: &str,
-    ) -> webb_relayer_utils::Result<Provider<Http>> {
+    ) -> webb_relayer_utils::Result<Provider<RetryClient<Http>>> {
         let chain_config = self.config.evm.get(chain_id).ok_or_else(|| {
             webb_relayer_utils::Error::ChainNotFound {
                 chain_id: chain_id.to_string(),
             }
         })?;
-        let provider = Provider::try_from(chain_config.http_endpoint.as_str())?
-            .interval(Duration::from_millis(5u64));
-        Ok(provider)
+        let client = Http::new(chain_config.http_endpoint.clone());
+        // Wrap the provider with a retry client.
+        let policy = Box::new(providers::HttpRateLimitRetryPolicy);
+        let retry_client = RetryClientBuilder::default().build(client, policy);
+        let proivder = Provider::new(retry_client);
+        Ok(proivder)
     }
     /// Sets up and returns an EVM wallet for the relayer.
     ///

--- a/crates/relayer-utils/src/lib.rs
+++ b/crates/relayer-utils/src/lib.rs
@@ -71,7 +71,7 @@ pub enum Error {
     EthersProvider(#[from] ethers::providers::ProviderError),
     /// Smart contract error.
     #[error(transparent)]
-    EthersContract(
+    EthersContractCall(
         #[from]
         ethers::contract::ContractError<
             ethers::providers::Provider<ethers::providers::Http>,
@@ -79,12 +79,22 @@ pub enum Error {
     ),
     /// Smart contract error.
     #[error(transparent)]
-    EthersContract2(
+    EthersContractCallWithSigner(
         #[from]
         ethers::contract::ContractError<
             ethers::middleware::SignerMiddleware<
                 ethers::providers::Provider<ethers::providers::Http>,
                 ethers::prelude::Wallet<ethers::core::k256::ecdsa::SigningKey>,
+            >,
+        >,
+    ),
+    /// Smart contract error.
+    #[error(transparent)]
+    EthersContractCallWithRetry(
+        #[from]
+        ethers::contract::ContractError<
+            ethers::providers::Provider<
+                ethers::providers::RetryClient<ethers::providers::Http>,
             >,
         >,
     ),

--- a/event-watchers/evm/src/lib.rs
+++ b/event-watchers/evm/src/lib.rs
@@ -21,7 +21,7 @@ use webb::evm::contract::protocol_solidity::{
 };
 use webb::evm::ethers::contract::Contract;
 use webb::evm::ethers::prelude::Middleware;
-use webb::evm::ethers::{providers, types};
+use webb::evm::ethers::types;
 
 pub mod signature_bridge_watcher;
 
@@ -36,6 +36,7 @@ pub mod vanchor;
 mod tests;
 
 use webb_event_watcher_traits::evm::{EventWatcher, WatchableContract};
+use webb_event_watcher_traits::EthersClient;
 use webb_relayer_store::SledStore;
 
 // VAnchorContractWrapper contains VAnchorContract contract along with configurations for Anchor contract, and Relayer.
@@ -101,8 +102,6 @@ where
     }
 }
 
-type HttpProvider = providers::Provider<providers::Http>;
-
 /// An Anchor Contract Watcher that watches for the Anchor contract events and calls the event
 /// handlers.
 #[derive(Copy, Clone, Debug, Default)]
@@ -117,7 +116,7 @@ pub struct VAnchorContractWatcher;
 impl EventWatcher for VAnchorContractWatcher {
     const TAG: &'static str = "VAnchor Contract Watcher";
 
-    type Contract = VAnchorContractWrapper<HttpProvider>;
+    type Contract = VAnchorContractWrapper<EthersClient>;
 
     type Events = VAnchorContractEvents;
 
@@ -196,7 +195,7 @@ pub struct OpenVAnchorContractWatcher;
 impl EventWatcher for OpenVAnchorContractWatcher {
     const TAG: &'static str = "Open VAnchor Contract Watcher";
 
-    type Contract = OpenVAnchorContractWrapper<HttpProvider>;
+    type Contract = OpenVAnchorContractWrapper<EthersClient>;
 
     type Events = OpenVAnchorContractEvents;
 

--- a/event-watchers/evm/src/open_vanchor/open_vanchor_deposit_handler.rs
+++ b/event-watchers/evm/src/open_vanchor/open_vanchor_deposit_handler.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{HttpProvider, OpenVAnchorContractWrapper};
+use super::OpenVAnchorContractWrapper;
 use ethereum_types::H256;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -20,6 +20,7 @@ use webb::evm::contract::protocol_solidity::OpenVAnchorContractEvents;
 use webb::evm::ethers::prelude::{LogMeta, Middleware};
 use webb_bridge_registry_backends::BridgeRegistryBackend;
 use webb_event_watcher_traits::evm::EventHandler;
+use webb_event_watcher_traits::EthersClient;
 use webb_proposal_signing_backends::{
     proposal_handler, ProposalSigningBackend,
 };
@@ -56,7 +57,7 @@ where
     B: ProposalSigningBackend + Send + Sync,
     C: BridgeRegistryBackend + Send + Sync,
 {
-    type Contract = OpenVAnchorContractWrapper<HttpProvider>;
+    type Contract = OpenVAnchorContractWrapper<EthersClient>;
 
     type Events = OpenVAnchorContractEvents;
 

--- a/event-watchers/evm/src/open_vanchor/open_vanchor_leaves_handler.rs
+++ b/event-watchers/evm/src/open_vanchor/open_vanchor_leaves_handler.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{HttpProvider, OpenVAnchorContractWrapper};
+use super::OpenVAnchorContractWrapper;
 use ethereum_types::H256;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use webb::evm::contract::protocol_solidity::OpenVAnchorContractEvents;
 use webb::evm::ethers::prelude::{LogMeta, Middleware};
 use webb_event_watcher_traits::evm::EventHandler;
+use webb_event_watcher_traits::EthersClient;
 use webb_proposals::{ResourceId, TargetSystem, TypedChainId};
 use webb_relayer_store::SledStore;
 use webb_relayer_store::{EventHashStore, LeafCacheStore};
@@ -30,7 +31,7 @@ pub struct OpenVAnchorLeavesHandler;
 
 #[async_trait::async_trait]
 impl EventHandler for OpenVAnchorLeavesHandler {
-    type Contract = OpenVAnchorContractWrapper<HttpProvider>;
+    type Contract = OpenVAnchorContractWrapper<EthersClient>;
 
     type Events = OpenVAnchorContractEvents;
 

--- a/event-watchers/evm/src/vanchor/vanchor_deposit_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_deposit_handler.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::VAnchorContractWrapper;
 use ethereum_types::H256;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -19,6 +20,7 @@ use webb::evm::contract::protocol_solidity::VAnchorContractEvents;
 use webb::evm::ethers::prelude::{LogMeta, Middleware};
 use webb_bridge_registry_backends::BridgeRegistryBackend;
 use webb_event_watcher_traits::evm::EventHandler;
+use webb_event_watcher_traits::EthersClient;
 use webb_proposal_signing_backends::{
     proposal_handler, ProposalSigningBackend,
 };
@@ -26,8 +28,6 @@ use webb_relayer_config::anchor::LinkedAnchorConfig;
 use webb_relayer_store::EventHashStore;
 use webb_relayer_store::SledStore;
 use webb_relayer_utils::metric;
-
-use crate::{HttpProvider, VAnchorContractWrapper};
 
 /// Represents an VAnchor Contract Watcher which will use a configured signing backend for signing proposals.
 pub struct VAnchorDepositHandler<B, C> {
@@ -57,7 +57,7 @@ where
     B: ProposalSigningBackend + Send + Sync,
     C: BridgeRegistryBackend + Send + Sync,
 {
-    type Contract = VAnchorContractWrapper<HttpProvider>;
+    type Contract = VAnchorContractWrapper<EthersClient>;
 
     type Events = VAnchorContractEvents;
 

--- a/event-watchers/evm/src/vanchor/vanchor_encrypted_outputs_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_encrypted_outputs_handler.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{HttpProvider, VAnchorContractWrapper};
+use super::VAnchorContractWrapper;
 use ethereum_types::H256;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use webb::evm::contract::protocol_solidity::VAnchorContractEvents;
 use webb::evm::ethers::prelude::{LogMeta, Middleware};
 use webb_event_watcher_traits::evm::EventHandler;
+use webb_event_watcher_traits::EthersClient;
 use webb_proposals::{ResourceId, TargetSystem, TypedChainId};
 use webb_relayer_store::SledStore;
 use webb_relayer_store::{EncryptedOutputCacheStore, EventHashStore};
@@ -31,7 +32,7 @@ pub struct VAnchorEncryptedOutputHandler;
 
 #[async_trait::async_trait]
 impl EventHandler for VAnchorEncryptedOutputHandler {
-    type Contract = VAnchorContractWrapper<HttpProvider>;
+    type Contract = VAnchorContractWrapper<EthersClient>;
 
     type Events = VAnchorContractEvents;
 

--- a/event-watchers/evm/src/vanchor/vanchor_leaves_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_leaves_handler.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{HttpProvider, VAnchorContractWrapper};
+use super::VAnchorContractWrapper;
 use ark_ff::{BigInteger, PrimeField};
 use arkworks_native_gadgets::poseidon::Poseidon;
 use arkworks_setups::common::setup_params;
@@ -23,8 +23,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use webb::evm::contract::protocol_solidity::VAnchorContractEvents;
-use webb::evm::ethers::prelude::{LogMeta, Middleware};
+use webb::evm::ethers::prelude::LogMeta;
+use webb::evm::ethers::providers::Middleware;
 use webb_event_watcher_traits::evm::EventHandler;
+use webb_event_watcher_traits::EthersClient;
 use webb_proposals::{ResourceId, TargetSystem, TypedChainId};
 use webb_relayer_store::{EventHashStore, LeafCacheStore};
 use webb_relayer_store::{HistoryStore, SledStore};
@@ -67,7 +69,7 @@ impl VAnchorLeavesHandler {
 
 #[async_trait::async_trait]
 impl EventHandler for VAnchorLeavesHandler {
-    type Contract = VAnchorContractWrapper<HttpProvider>;
+    type Contract = VAnchorContractWrapper<EthersClient>;
 
     type Events = VAnchorContractEvents;
 

--- a/services/block-poller/src/block_poller.rs
+++ b/services/block-poller/src/block_poller.rs
@@ -90,7 +90,9 @@ pub trait BlockPoller {
     )]
     async fn run(
         &self,
-        client: Arc<providers::Provider<providers::Http>>,
+        client: Arc<
+            providers::Provider<providers::RetryClient<providers::Http>>,
+        >,
         store: Arc<Self::Store>,
         listener_config: BlockPollerConfig,
         handlers: Vec<BlockPollingHandlerFor<Self>>,

--- a/services/webb-relayer/src/service/evm.rs
+++ b/services/webb-relayer/src/service/evm.rs
@@ -2,10 +2,9 @@ use std::sync::Arc;
 
 use axum::routing::get;
 use axum::Router;
-use webb::evm::ethers::providers;
 use webb_bridge_registry_backends::dkg::DkgBridgeRegistryBackend;
 use webb_bridge_registry_backends::mocked::MockedBridgeRegistryBackend;
-use webb_event_watcher_traits::{BridgeWatcher, EventWatcher};
+use webb_event_watcher_traits::{BridgeWatcher, EthersClient, EventWatcher};
 use webb_ew_evm::open_vanchor::{
     OpenVAnchorDepositHandler, OpenVAnchorLeavesHandler,
 };
@@ -33,7 +32,7 @@ use super::make_proposal_signing_backend;
 use super::ProposalSigningBackendSelector;
 
 /// Type alias for providers
-pub type Client = providers::Provider<providers::Http>;
+pub type Client = EthersClient;
 
 /// Setup and build all the EVM web services and handlers.
 pub fn build_web_services() -> Router<Arc<RelayerContext>> {


### PR DESCRIPTION
## Summary of changes
- Wraps every EVM provider with a [`RetryClient`](https://docs.rs/ethers/2.0.4/ethers/providers/struct.RetryClient.html)


### Reference issue to close (if applicable)
- Closes #491 

-----
### Code Checklist 

- [ ] Tested
- [x] Documented
