### PR TITLE
bugfix: building MerkleTree history

### DIFF
--- a/crates/event-watcher-traits/src/evm/event_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/event_watcher.rs
@@ -275,7 +275,7 @@ pub trait EventHandler {
     /// Whether any of the events could be handled by the handler
     async fn can_handle_events(
         &self,
-        event: Self::Events,
+        (event, log): (Self::Events, contract::LogMeta),
         wrapper: &Self::Contract,
     ) -> webb_relayer_utils::Result<bool>;
 }
@@ -303,7 +303,10 @@ pub trait EventHandlerWithRetry: EventHandler {
         backoff: impl backoff::backoff::Backoff + Send + Sync + 'static,
         metrics: Arc<Mutex<metric::Metrics>>,
     ) -> webb_relayer_utils::Result<()> {
-        if !self.can_handle_events(event.clone(), contract).await? {
+        if !self
+            .can_handle_events((event.clone(), log.clone()), contract)
+            .await?
+        {
             return Ok(());
         };
 

--- a/event-watchers/evm/src/open_vanchor/open_vanchor_deposit_handler.rs
+++ b/event-watchers/evm/src/open_vanchor/open_vanchor_deposit_handler.rs
@@ -65,7 +65,7 @@ where
 
     async fn can_handle_events(
         &self,
-        events: Self::Events,
+        (events, _logs): (Self::Events, LogMeta),
         _wrapper: &Self::Contract,
     ) -> webb_relayer_utils::Result<bool> {
         use OpenVAnchorContractEvents::*;

--- a/event-watchers/evm/src/open_vanchor/open_vanchor_leaves_handler.rs
+++ b/event-watchers/evm/src/open_vanchor/open_vanchor_leaves_handler.rs
@@ -39,7 +39,7 @@ impl EventHandler for OpenVAnchorLeavesHandler {
 
     async fn can_handle_events(
         &self,
-        events: Self::Events,
+        (events, _meta): (Self::Events, LogMeta),
         _wrapper: &Self::Contract,
     ) -> webb_relayer_utils::Result<bool> {
         use OpenVAnchorContractEvents::*;

--- a/event-watchers/evm/src/signature_bridge_watcher.rs
+++ b/event-watchers/evm/src/signature_bridge_watcher.rs
@@ -121,7 +121,7 @@ impl EventHandler for SignatureBridgeGovernanceOwnershipTransferredHandler {
 
     async fn can_handle_events(
         &self,
-        events: Self::Events,
+        (events, _meta): (Self::Events, LogMeta),
         _wrapper: &Self::Contract,
     ) -> webb_relayer_utils::Result<bool> {
         use SignatureBridgeContractEvents::*;

--- a/event-watchers/evm/src/vanchor/vanchor_encrypted_outputs_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_encrypted_outputs_handler.rs
@@ -40,7 +40,7 @@ impl EventHandler for VAnchorEncryptedOutputHandler {
 
     async fn can_handle_events(
         &self,
-        events: Self::Events,
+        (events, _meta): (Self::Events, LogMeta),
         _wrapper: &Self::Contract,
     ) -> webb_relayer_utils::Result<bool> {
         use VAnchorContractEvents::*;

--- a/services/webb-relayer/src/service/evm.rs
+++ b/services/webb-relayer/src/service/evm.rs
@@ -158,10 +158,6 @@ async fn start_vanchor_events_watcher(
     let contract_address = config.common.address;
     let my_ctx = ctx.clone();
     let my_config = config.clone();
-    let default_leaf = wrapper.contract.get_zero_hash(0).call().await?;
-
-    let mut default_leaf_bytes = [0u8; 32];
-    default_leaf.to_big_endian(&mut default_leaf_bytes);
     let task = async move {
         tracing::debug!(
             "VAnchor events watcher for ({}) Started.",
@@ -176,6 +172,10 @@ async fn start_vanchor_events_watcher(
             my_config.proposal_signing_backend,
         )
         .await?;
+
+        let default_leaf = wrapper.contract.get_zero_hash(0).call().await?;
+        let mut default_leaf_bytes = [0u8; 32];
+        default_leaf.to_big_endian(&mut default_leaf_bytes);
         match proposal_signing_backend {
             ProposalSigningBackendSelector::Dkg(backend) => {
                 let bridge_registry =


### PR DESCRIPTION
## Summary of changes
- `can_handle_events` now takes `LogMeta`
- when calling `is_known_root`, we now add the block number where this event happened.
-  only handle update proposals when we are considered `fully_synced`


### Reference issue to close (if applicable)
- Closes #498 

Note that, a better solution would be that when we emit the commitment, we also emit the merkle root at this point of time, so we do not have to query historical blocks as ("nodes only keep the most recent 256 states by default", prestwich)

-----
### Code Checklist 

- [ ] Tested
- [x] Documented
