### PR TITLE
feature: Optmize the usage of RPCs and Resoruces

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -58,16 +58,12 @@ jobs:
       - name: install system build dependencies
         run: sudo apt-get update && sudo apt-get install ${DEV_PACKAGES}
       - uses: actions/checkout@v2
-      - name: Cache Cargo
-        uses: actions/cache@v2
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target/x86_64-unknown-linux-musl
-            target/release
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-x86_64-unknown-linux-musl
+          shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
+
       - uses: actions/download-artifact@v1
         with:
           name: cross-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: Cache Cargo
-        uses: actions/cache@v2
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.target }}
+          shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
       - uses: actions/download-artifact@v1
         with:
           name: cross-apple-darwin
@@ -107,15 +103,11 @@ jobs:
       - name: install system build dependencies
         run: sudo apt-get update && sudo apt-get install ${DEV_PACKAGES}
       - uses: actions/checkout@v2
-      - name: Cache Cargo
-        uses: actions/cache@v2
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.target }}
+          shared-key: "rust"
+          cache-directories: ".dvc/tmp\n.dvc/cache"
       - uses: actions/download-artifact@v1
         with:
           name: cross-linux-musl

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -68,11 +68,11 @@ private-key = "$PRIVATE_KEY"
 # - SignatureBridge
 contract = "VAnchor"
 # The address of the contract
-address = "0x9678647b9fcb0039652a16dba688bd067d6e5077"
+address = "0x38e7aa90c77f86747fab355eecaa0c2e4c3a463d"
 # The deployed block number of the contract. When a relayer does not have information for
 # this contract in its store, it will start to sync and query for relevant historical data
 # starting at this block number
-deployed-at = 8648487
+deployed-at = 8703495
 # Configuration for the events watcher of this contract. The events-watcher can be switched on/off
 # and the polling interval specifies the period of time (in ms) that the events-watcher thread
 # will wait before issuing another query for new events.

--- a/crates/event-watcher-traits/src/evm/event_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/event_watcher.rs
@@ -64,7 +64,6 @@ pub trait EventWatcher {
     #[tracing::instrument(
         skip_all,
         fields(
-            chain_id = ?client.get_chainid().await,
             address = %contract.address(),
             tag = %Self::TAG,
         ),

--- a/crates/event-watcher-traits/src/evm/event_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/event_watcher.rs
@@ -79,8 +79,6 @@ pub trait EventWatcher {
         let backoff = backoff::backoff::Constant::new(Duration::from_secs(1));
         let task = || async {
             let step = contract.max_blocks_per_step().as_u64();
-            // saves the last time we printed sync progress.
-            let mut instant = std::time::Instant::now();
             let metrics = &ctx.metrics;
             let chain_id: u32 = client
                 .get_chainid()
@@ -88,114 +86,100 @@ pub trait EventWatcher {
                 .map_err(backoff::Error::transient)
                 .await?
                 .as_u32();
-            let chain_config =
-                ctx.config.evm.get(&chain_id.to_string()).ok_or_else(|| {
-                    webb_relayer_utils::Error::ChainNotFound {
-                        chain_id: chain_id.clone().to_string(),
-                    }
-                })?;
-            // no of blocks confirmation required before processing it
-            let block_confirmations: u64 =
-                chain_config.block_confirmations.into();
             // now we start polling for new events.
+            // create history store key
+            let src_target_system = TargetSystem::new_contract_address(
+                contract.address().to_fixed_bytes(),
+            );
+            let src_typed_chain_id = TypedChainId::Evm(chain_id);
+            let history_store_key =
+                ResourceId::new(src_target_system, src_typed_chain_id);
+
+            // saves the last time we printed sync progress.
+            let mut instant = std::time::Instant::now();
+            // we only query this once, at the start of the events watcher.
+            // then we will update it later once we fully synced.
+            let mut latest_block_number = client
+                .get_block_number()
+                .map_err(Into::into)
+                .map_err(backoff::Error::transient)
+                .await?
+                .as_u64();
+
             loop {
-                // create history store key
-                let src_target_system = TargetSystem::new_contract_address(
-                    contract.address().to_fixed_bytes(),
-                );
-                let src_typed_chain_id = TypedChainId::Evm(chain_id);
-                let history_store_key =
-                    ResourceId::new(src_target_system, src_typed_chain_id);
                 let block = store.get_last_block_number(
                     history_store_key,
                     contract.deployed_at().as_u64(),
                 )?;
-                let current_block_number = client
-                    .get_block_number()
+                let dest_block =
+                    core::cmp::min(block + step, latest_block_number);
+
+                let events_filter = contract
+                    .event_with_filter::<Self::Events>(Default::default())
+                    .from_block(block + 1)
+                    .to_block(dest_block);
+                let found_events = events_filter
+                    .query_with_meta()
                     .map_err(Into::into)
                     .map_err(backoff::Error::transient)
                     .await?;
-                let current_block_number = current_block_number.as_u64();
-                tracing::trace!(
-                    "Latest block number: #{}",
-                    current_block_number
-                );
-                // latest finalized block after n block_confirmations
-                let latest_finalized_block =
-                    current_block_number.saturating_sub(block_confirmations);
-                let dest_block = cmp::min(block + step, latest_finalized_block);
-                // check if we are now on the latest block.
-                let should_cooldown = dest_block == latest_finalized_block;
-                tracing::trace!("Reading from #{} to #{}", block, dest_block);
-                // Only handle events from found blocks if they are new
-                if dest_block != block {
-                    let events_filter = contract
-                        .event_with_filter::<Self::Events>(Default::default())
-                        .from_block(block + 1)
-                        .to_block(dest_block);
-                    let found_events = events_filter
-                        .query_with_meta()
-                        .map_err(Into::into)
-                        .map_err(backoff::Error::transient)
-                        .await?;
 
-                    tracing::trace!("Found #{} events", found_events.len());
-
-                    for (event, log) in found_events {
-                        // wraps each handler future in a retry logic, that will retry the handler
-                        // if it fails, up to `MAX_RETRY_COUNT`, after this it will ignore that event for
-                        // that specific handler.
-                        const MAX_RETRY_COUNT: usize = 5;
-                        let tasks = handlers.iter().map(|handler| {
-                            // a constant backoff with maximum retry count is used here.
-                            let backoff = retry::ConstantWithMaxRetryCount::new(
-                                Duration::from_millis(100),
-                                MAX_RETRY_COUNT,
-                            );
-                            handler.handle_event_with_retry(
-                                store.clone(),
-                                &contract,
-                                (event.clone(), log.clone()),
-                                backoff,
-                                metrics.clone(),
-                            )
-                        });
-                        let result = futures::future::join_all(tasks).await;
-                        // this event will be marked as handled if at least one handler succeeded.
-                        // this because, for the failed events, we arleady tried to handle them
-                        // many times (at this point), and there is no point in trying again.
-                        let mark_as_handled = result.iter().any(Result::is_ok);
-                        // also, for all the failed event handlers, we should print what went
-                        // wrong.
-                        result.iter().for_each(|r| {
+                let number_of_events = found_events.len();
+                tracing::trace!("Found #{number_of_events} events");
+                for (event, log) in found_events {
+                    // wraps each handler future in a retry logic, that will retry the handler
+                    // if it fails, up to `MAX_RETRY_COUNT`, after this it will ignore that event for
+                    // that specific handler.
+                    const MAX_RETRY_COUNT: usize = 5;
+                    let tasks = handlers.iter().map(|handler| {
+                        // a constant backoff with maximum retry count is used here.
+                        let backoff = retry::ConstantWithMaxRetryCount::new(
+                            Duration::from_millis(100),
+                            MAX_RETRY_COUNT,
+                        );
+                        handler.handle_event_with_retry(
+                            store.clone(),
+                            &contract,
+                            (event.clone(), log.clone()),
+                            backoff,
+                            metrics.clone(),
+                        )
+                    });
+                    let result = futures::future::join_all(tasks).await;
+                    // this event will be marked as handled if at least one handler succeeded.
+                    // this because, for the failed events, we arleady tried to handle them
+                    // many times (at this point), and there is no point in trying again.
+                    let mark_as_handled = result.iter().any(Result::is_ok);
+                    // also, for all the failed event handlers, we should print what went
+                    // wrong.
+                    result.iter().for_each(|r| {
                             if let Err(e) = r {
-                                tracing::error!("{}", e);
+                                tracing::error!(?e, %chain_id, "Error while handling the event");
                             }
                         });
-                        if mark_as_handled {
-                            store.set_last_block_number(
-                                history_store_key,
-                                log.block_number.as_u64(),
-                            )?;
-                            tracing::trace!(
-                                "event handled successfully. at #{}",
-                                log.block_number
-                            );
-                        } else {
-                            tracing::error!("Error while handling event, all handlers failed.");
-                            tracing::warn!("Restarting event watcher ...");
-                            // this a transient error, so we will retry again.
-                            return Err(backoff::Error::transient(
-                                webb_relayer_utils::Error::ForceRestart,
-                            ));
-                        }
+                    if mark_as_handled {
+                        store.set_last_block_number(
+                            history_store_key,
+                            log.block_number.as_u64(),
+                        )?;
+                        tracing::trace!(
+                            %chain_id,
+                            %log.block_number,
+                            "event handled successfully",
+                        );
+                    } else {
+                        tracing::error!(%chain_id, "Error while handling event, all handlers failed.");
+                        tracing::warn!(%chain_id, "Restarting event watcher ...");
+                        // this a transient error, so we will retry again.
+                        return Err(backoff::Error::transient(
+                            webb_relayer_utils::Error::ForceRestart,
+                        ));
                     }
-                    // move forward.
-                    store
-                        .set_last_block_number(history_store_key, dest_block)?;
-                    tracing::trace!("Last saved block number: #{}", dest_block);
                 }
-                tracing::trace!("Polled from #{} to #{}", block, dest_block);
+
+                // move the block pointer to the destination block
+                store.set_last_block_number(history_store_key, dest_block)?;
+                let should_cooldown = dest_block == latest_block_number;
                 if should_cooldown {
                     let duration = contract.polling_interval();
                     tracing::trace!(
@@ -203,34 +187,41 @@ pub trait EventWatcher {
                         duration.as_millis()
                     );
                     tokio::time::sleep(duration).await;
+                    // update the latest block number
+                    latest_block_number = client
+                        .get_block_number()
+                        .map_err(Into::into)
+                        .map_err(backoff::Error::transient)
+                        .await?
+                        .as_u64();
                 }
 
-                // only print the progress if 7 seconds (by default) is passed.
                 if contract.print_progress_interval()
                     != Duration::from_millis(0)
                     && instant.elapsed() > contract.print_progress_interval()
                 {
-                    // calculate sync progress.
-                    let total = current_block_number as f64;
-                    let current_value = dest_block as f64;
-                    let diff = total - current_value;
-                    let percentage = (diff / current_value) * 100.0;
-                    // should be always less that 100.
-                    // and this would be our current progress.
-                    let sync_progress = 100.0 - percentage;
+                    let currently_at = store.get_last_block_number(
+                        history_store_key,
+                        contract.deployed_at().as_u64(),
+                    )?;
+                    let diff = currently_at.saturating_sub(block);
+                    let progress = currently_at as f64 / latest_block_number as f64 * 100.0;
+                    let is_syncing = progress > 99.9;
                     tracing::info!(
-                        "🔄 #{} of #{} ({:.4}%)",
-                        dest_block,
-                        current_block_number,
-                        sync_progress
+                        target_block = latest_block_number,
+                        currently_at,
+                        diff,
+                        is_syncing,
+                        progress,
+                        %chain_id
                     );
                     tracing::event!(
                         target: webb_relayer_utils::probe::TARGET,
                         tracing::Level::TRACE,
                         kind = %webb_relayer_utils::probe::Kind::Sync,
+                        %chain_id,
                         %block,
                         %dest_block,
-                        %sync_progress,
                     );
                     instant = std::time::Instant::now();
                 }

--- a/crates/event-watcher-traits/src/evm/mod.rs
+++ b/crates/event-watcher-traits/src/evm/mod.rs
@@ -16,7 +16,6 @@
 //! # EVM Events Watcher Traits 🕸️
 
 use futures::prelude::*;
-use std::cmp;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/relayer-config/src/defaults.rs
+++ b/crates/relayer-config/src/defaults.rs
@@ -14,7 +14,7 @@ pub const fn enable_data_query() -> bool {
 }
 /// The maximum events per step is set to `100` by default.
 pub const fn max_blocks_per_step() -> u64 {
-    100
+    500
 }
 /// The print progress interval is set to `7_000` by default.
 pub const fn print_progress_interval() -> u64 {

--- a/crates/relayer-handlers/src/routes/leaves.rs
+++ b/crates/relayer-handlers/src/routes/leaves.rs
@@ -116,7 +116,12 @@ pub async fn handle_leaves_cache_evm(
         ResourceId::new(src_target_system, src_typed_chain_id);
     let leaves = ctx
         .store()
-        .get_leaves_with_range(history_store_key, query_range.into())?;
+        .get_leaves_with_range(history_store_key, query_range.into())
+        .map(|tree| {
+            tree.into_values()
+                .map(|v| v.to_fixed_bytes().to_vec())
+                .collect::<Vec<_>>()
+        })?;
     let last_queried_block = ctx
         .store()
         .get_last_deposit_block_number(history_store_key)?;
@@ -165,7 +170,12 @@ pub async fn handle_leaves_cache_substrate(
 
     let leaves = ctx
         .store()
-        .get_leaves_with_range(history_store_key, query_range.into())?;
+        .get_leaves_with_range(history_store_key, query_range.into())
+        .map(|tree| {
+            tree.into_values()
+                .map(|v| v.to_fixed_bytes().to_vec())
+                .collect::<Vec<_>>()
+        })?;
     let last_queried_block = ctx
         .store()
         .get_last_deposit_block_number(history_store_key)?;

--- a/crates/relayer-store/src/lib.rs
+++ b/crates/relayer-store/src/lib.rs
@@ -242,7 +242,7 @@ pub trait EventHashStore: Send + Sync + Clone {
 /// getting the leaves and insert them with a simple API.
 pub trait LeafCacheStore: HistoryStore {
     /// The Output type which is the leaf.
-    type Output: IntoIterator<Item = Vec<u8>>;
+    type Output: IntoIterator<Item = (u32, types::H256)>;
 
     /// Clear leaf cache on relayer
     fn clear_leaves_cache<K: Into<HistoryStoreKey> + Debug>(

--- a/crates/relayer-store/src/sled.rs
+++ b/crates/relayer-store/src/sled.rs
@@ -16,9 +16,10 @@ use crate::{BridgeKey, QueueKey};
 use core::fmt;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::path::Path;
-use webb::evm::ethers;
+use webb::evm::ethers::{self, types};
 
 use super::HistoryStoreKey;
 use super::{
@@ -101,7 +102,7 @@ impl HistoryStore for SledStore {
 }
 
 impl LeafCacheStore for SledStore {
-    type Output = Vec<Vec<u8>>;
+    type Output = BTreeMap<u32, types::H256>;
 
     #[tracing::instrument(skip(self))]
     fn clear_leaves_cache<K: Into<HistoryStoreKey> + Debug>(
@@ -128,9 +129,20 @@ impl LeafCacheStore for SledStore {
             key.chain_id(),
             key.address()
         ))?;
-        let leaves =
-            tree.iter().values().flatten().map(|v| v.to_vec()).collect();
-        Ok(leaves)
+        let leaves_map: BTreeMap<_, _> = tree
+            .iter()
+            .flatten()
+            .map(|(k, v)| {
+                let leaf_index_bytes = k.get(0..4).expect("leaf index bytes");
+                let leaf_index_bytes = leaf_index_bytes
+                    .try_into()
+                    .expect("leaf index bytes is u32 bytes");
+                let leaf_index = u32::from_le_bytes(leaf_index_bytes);
+                let leaf = types::H256::from_slice(&v);
+                (leaf_index, leaf)
+            })
+            .collect();
+        Ok(leaves_map)
     }
 
     #[tracing::instrument(skip(self))]
@@ -149,9 +161,16 @@ impl LeafCacheStore for SledStore {
         let range_end = range.end.to_le_bytes();
         let leaves = tree
             .range(range_start..range_end)
-            .values()
             .flatten()
-            .map(|v| v.to_vec())
+            .map(|(k, v)| {
+                let leaf_index_bytes = k.get(0..4).expect("leaf index bytes");
+                let leaf_index_bytes = leaf_index_bytes
+                    .try_into()
+                    .expect("leaf index bytes is u32 bytes");
+                let leaf_index = u32::from_le_bytes(leaf_index_bytes);
+                let leaf = types::H256::from_slice(&v);
+                (leaf_index, leaf)
+            })
             .collect();
         Ok(leaves)
     }
@@ -167,9 +186,12 @@ impl LeafCacheStore for SledStore {
             key.chain_id(),
             key.address()
         ))?;
-        for (k, v) in leaves {
-            tree.insert(k.to_le_bytes(), v.as_slice())?;
-        }
+        tree.transaction(|db| {
+            for (k, v) in leaves {
+                db.insert(&k.to_le_bytes(), v.as_slice())?;
+            }
+            Ok(())
+        })?;
         Ok(())
     }
 
@@ -200,7 +222,10 @@ impl LeafCacheStore for SledStore {
         let tree = self.db.open_tree("last_deposit_block_number")?;
         let bytes = block_number.to_le_bytes();
         let key: HistoryStoreKey = key.into();
-        let old = tree.insert(key.to_bytes(), &bytes)?;
+        let old = tree.transaction(|db| {
+            let old = db.insert(key.to_bytes(), &bytes)?;
+            Ok(old)
+        })?;
         match old {
             Some(v) => {
                 let mut output = [0u8; 8];
@@ -703,7 +728,10 @@ mod tests {
             .unwrap();
         assert_eq!(leaves.len(), 5);
         assert_eq!(
-            leaves,
+            leaves
+                .values()
+                .map(|v| v.to_fixed_bytes().to_vec())
+                .collect::<Vec<_>>(),
             generated_leaves
                 .into_iter()
                 .skip(5)

--- a/crates/relayer-utils/src/lib.rs
+++ b/crates/relayer-utils/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use webb::{evm::ethers, substrate::subxt};
@@ -88,6 +90,7 @@ pub enum Error {
             >,
         >,
     ),
+
     /// Smart contract error.
     #[error(transparent)]
     EthersContractCallWithRetry(
@@ -95,6 +98,18 @@ pub enum Error {
         ethers::contract::ContractError<
             ethers::providers::Provider<
                 ethers::providers::RetryClient<ethers::providers::Http>,
+            >,
+        >,
+    ),
+    /// Smart contract error.
+    #[error(transparent)]
+    EthersContractCallWithRetryCloneable(
+        #[from]
+        ethers::contract::ContractError<
+            Arc<
+                ethers::providers::Provider<
+                    ethers::providers::RetryClient<ethers::providers::Http>,
+                >,
             >,
         >,
     ),

--- a/crates/tx-queue/src/evm/evm_tx_queue.rs
+++ b/crates/tx-queue/src/evm/evm_tx_queue.rs
@@ -65,12 +65,12 @@ where
     #[tracing::instrument(skip_all, fields(chain = %self.chain_id))]
     pub async fn run(self) -> webb_relayer_utils::Result<()> {
         let provider = self.ctx.evm_provider(&self.chain_id).await?;
-        let wallet = self.ctx.evm_wallet(&self.chain_id).await?;
+        let wallet = self.ctx.evm_wallet(self.chain_id).await?;
         let client = Arc::new(SignerMiddleware::new(provider, wallet));
         let chain_config =
-            self.ctx.config.evm.get(&self.chain_id).ok_or_else(|| {
+            self.ctx.config.evm.get(&self.chain_id.as_u64().to_string()).ok_or_else(|| {
                 webb_relayer_utils::Error::ChainNotFound {
-                    chain_id: self.chain_id.clone(),
+                    chain_id: self.chain_id.to_string(),
                 }
             })?;
         let chain_id = client

--- a/crates/tx-queue/src/evm/evm_tx_queue.rs
+++ b/crates/tx-queue/src/evm/evm_tx_queue.rs
@@ -22,6 +22,7 @@ use webb::evm::ethers::core::types::transaction::eip2718::TypedTransaction;
 use webb::evm::ethers::middleware::SignerMiddleware;
 use webb::evm::ethers::providers::Middleware;
 
+use webb::evm::ethers::types;
 use webb_relayer_context::RelayerContext;
 use webb_relayer_store::sled::SledQueueKey;
 use webb_relayer_store::QueueStore;
@@ -34,7 +35,7 @@ use webb_relayer_utils::clickable_link::ClickableLink;
 #[derive(Clone)]
 pub struct TxQueue<S: QueueStore<TypedTransaction>> {
     ctx: RelayerContext,
-    chain_id: String,
+    chain_id: types::U256,
     store: Arc<S>,
 }
 
@@ -51,7 +52,7 @@ where
     /// * `ctx` - RelayContext reference that holds the configuration
     /// * `chain_id` - The chainId that this queue is for
     /// * `store` - [Sled](https://sled.rs)-based database store
-    pub fn new(ctx: RelayerContext, chain_id: String, store: Arc<S>) -> Self {
+    pub fn new(ctx: RelayerContext, chain_id: types::U256, store: Arc<S>) -> Self {
         Self {
             ctx,
             chain_id,

--- a/crates/tx-relay/src/evm/fees.rs
+++ b/crates/tx-relay/src/evm/fees.rs
@@ -221,8 +221,7 @@ async fn get_wrapped_token_name_and_decimals(
     vanchor: Address,
     ctx: &RelayerContext,
 ) -> Result<(String, u32)> {
-    let chain_name = chain_id.underlying_chain_id().to_string();
-    let provider = ctx.evm_provider(&chain_name).await?;
+    let provider = ctx.evm_provider(chain_id.underlying_chain_id()).await?;
     let client = Arc::new(provider);
 
     let anchor_contract = VAnchorContract::new(vanchor, client.clone());

--- a/crates/tx-relay/src/evm/vanchor.rs
+++ b/crates/tx-relay/src/evm/vanchor.rs
@@ -52,7 +52,7 @@ pub async fn handle_vanchor_relay_tx<'a>(
         .ok_or(Network(NetworkStatus::UnsupportedContract))?;
 
     let wallet =
-        ctx.evm_wallet(&cmd.chain_id.to_string())
+        ctx.evm_wallet(cmd.chain_id)
             .await
             .map_err(|e| {
                 Error(format!("Misconfigured Network: {:?}, {e}", cmd.chain_id))
@@ -78,7 +78,7 @@ pub async fn handle_vanchor_relay_tx<'a>(
     );
     let _ = stream.send(Network(NetworkStatus::Connecting)).await;
     let provider =
-        ctx.evm_provider(&cmd.chain_id.to_string())
+        ctx.evm_provider(cmd.chain_id)
             .await
             .map_err(|e| {
                 Network(NetworkStatus::Failed {

--- a/event-watchers/evm/src/vanchor/vanchor_deposit_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_deposit_handler.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use webb::evm::contract::protocol_solidity::VAnchorContractEvents;
 use webb::evm::ethers::prelude::{LogMeta, Middleware};
+use webb::evm::ethers::types;
 use webb_bridge_registry_backends::BridgeRegistryBackend;
 use webb_event_watcher_traits::evm::EventHandler;
 use webb_event_watcher_traits::EthersClient;
@@ -33,6 +34,7 @@ use webb_relayer_utils::metric;
 pub struct VAnchorDepositHandler<B, C> {
     proposal_signing_backend: B,
     bridge_registry_backend: C,
+    chain_id: types::U256,
 }
 
 impl<B, C> VAnchorDepositHandler<B, C>
@@ -43,10 +45,12 @@ where
     pub fn new(
         proposal_signing_backend: B,
         bridge_registry_backend: C,
+        chain_id: types::U256,
     ) -> Self {
         Self {
             proposal_signing_backend,
             bridge_registry_backend,
+            chain_id,
         }
     }
 }

--- a/event-watchers/evm/src/vanchor/vanchor_leaves_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_leaves_handler.rs
@@ -24,12 +24,12 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use webb::evm::contract::protocol_solidity::VAnchorContractEvents;
 use webb::evm::ethers::prelude::LogMeta;
-use webb::evm::ethers::providers::Middleware;
+use webb::evm::ethers::types;
 use webb_event_watcher_traits::evm::EventHandler;
 use webb_event_watcher_traits::EthersClient;
 use webb_proposals::{ResourceId, TargetSystem, TypedChainId};
+use webb_relayer_store::SledStore;
 use webb_relayer_store::{EventHashStore, LeafCacheStore};
-use webb_relayer_store::{HistoryStore, SledStore};
 use webb_relayer_utils::metric;
 
 use ark_bn254::Fr as Bn254Fr;
@@ -42,29 +42,59 @@ type MerkleTree = SparseMerkleTree<Bn254Fr, Poseidon<Bn254Fr>, 30>;
 
 pub struct VAnchorLeavesHandler {
     mt: Arc<Mutex<MerkleTree>>,
-    storage: Arc<SledStore>,
     hasher: Poseidon<Bn254Fr>,
+    chain_id: types::U256,
 }
+
 impl VAnchorLeavesHandler {
+    /// Creates a new Leaves Handler for the given contract address.
+    /// on the given chain id.
+    ///
+    /// Using the storage, it will try to load any old leaves and
+    /// construct the merkle tree in memory.
     pub fn new(
+        chain_id: types::U256,
+        contract_address: types::Address,
         storage: Arc<SledStore>,
-        default_leaf: Vec<u8>,
+        empty_leaf: Vec<u8>,
     ) -> webb_relayer_utils::Result<Self> {
         let params = setup_params::<Bn254Fr>(Curve::Bn254, 5, 3);
         let poseidon = Poseidon::<Bn254Fr>::new(params);
-        let default_leaf_scalar: Vec<Bn254Fr> =
-            bytes_vec_to_f(&vec![default_leaf]);
-        let default_leaf_vec = default_leaf_scalar
+        let empty_leaf_scalar: Vec<Bn254Fr> = bytes_vec_to_f(&vec![empty_leaf]);
+        let empty_leaf_vec = empty_leaf_scalar
             .get(0)
             .map(|d| d.into_repr().to_bytes_be())
             .ok_or(webb_relayer_utils::Error::ConvertLeafScalarError)?;
-        let pairs: BTreeMap<u32, Bn254Fr> = BTreeMap::new();
-        let mt = MerkleTree::new(&pairs, &poseidon, &default_leaf_vec)?;
+
+        let target_system = TargetSystem::new_contract_address(
+            contract_address.to_fixed_bytes(),
+        );
+        let typed_chain_id = TypedChainId::Evm(chain_id.as_u32());
+        let history_store_key = ResourceId::new(target_system, typed_chain_id);
+        // Load all the old leaves
+        let leaves = storage.get_leaves(history_store_key)?;
+        let mut batch: BTreeMap<u32, Bn254Fr> = BTreeMap::new();
+        for (i, leaf) in leaves.into_iter() {
+            tracing::trace!(
+                leaf_index = i,
+                leaf = hex::encode(leaf.as_bytes()),
+                "Inserting leaf into merkle tree",
+            );
+
+            let leaf: Bn254Fr =
+                Bn254Fr::from_be_bytes_mod_order(leaf.as_bytes());
+            batch.insert(i as _, leaf);
+        }
+        let mt = MerkleTree::new(&batch, &poseidon, &empty_leaf_vec)?;
+        tracing::debug!(
+            root = hex::encode(mt.root().into_repr().to_bytes_be()),
+            "Loaded merkle tree from store",
+        );
 
         Ok(Self {
+            chain_id,
             mt: Arc::new(Mutex::new(mt)),
             hasher: poseidon,
-            storage,
         })
     }
 }
@@ -92,15 +122,23 @@ impl EventHandler for VAnchorLeavesHandler {
             NewCommitmentFilter(event_data) => {
                 let leaf_index = event_data.leaf_index.as_u32();
                 let commitment: [u8; 32] = event_data.commitment.into();
-
                 let leaf: Bn254Fr =
                     Bn254Fr::from_be_bytes_mod_order(commitment.as_slice());
                 let mut batch: BTreeMap<u32, Bn254Fr> = BTreeMap::new();
                 batch.insert(leaf_index, leaf);
                 let mut mt = self.mt.lock().await;
                 mt.insert_batch(&batch, &self.hasher)?;
+                // if leaf index is even number then we don't need to verify commitment
+                if event_data.leaf_index.as_u32() % 2 == 0 {
+                    tracing::debug!(
+                        leaf_index = leaf_index,
+                        commitment = hex::encode(commitment.as_slice()),
+                        "Verified commitment",
+                    );
+                    return Ok(true);
+                }
                 let root_bytes = mt.root().into_repr().to_bytes_be();
-                let root: U256 = U256::from_big_endian(root_bytes.as_slice());
+                let root = U256::from_big_endian(root_bytes.as_slice());
                 let is_known_root = wrapper
                     .contract
                     .is_known_root(root)
@@ -108,47 +146,20 @@ impl EventHandler for VAnchorLeavesHandler {
                     .call()
                     .await?;
 
-                tracing::trace!("Is known root: {:?}", is_known_root);
-
-                if event_data.leaf_index.as_u32() % 2 == 0 {
-                    return Ok(true);
-                }
+                tracing::debug!(
+                    leaf_index = leaf_index,
+                    root = hex::encode(root_bytes.as_slice()),
+                    is_known_root,
+                    "New commitment need to be verified",
+                );
 
                 if !is_known_root {
-                    tracing::warn!("Invalid merkle root .. Restarting");
-                    // In case of invalid merkle root, relayer should clear its storage and restart syncing.
-                    // 1. We define history store key which will be used to access storage.
-                    let chain_id =
-                        wrapper.contract.client().get_chainid().await?;
-                    let target_system = TargetSystem::new_contract_address(
-                        wrapper.contract.address().to_fixed_bytes(),
-                    );
-                    let typed_chain_id = TypedChainId::Evm(chain_id.as_u32());
-                    let history_store_key =
-                        ResourceId::new(target_system, typed_chain_id);
-
-                    // 2. Clear merkle tree on relayer.
-                    tracing::warn!("Clear merkle tree...!");
-                    mt.tree.clear();
-                    // 3. Clear LeafStore cache on relayer.
-                    tracing::warn!("Clear local leaves cache...!");
-                    self.storage.clear_leaves_cache(history_store_key)?;
-                    // 4. Reset last block no processed by leaf handler.
-                    tracing::warn!("Clear last deposit block number...!");
-                    self.storage.insert_last_deposit_block_number(
-                        history_store_key,
-                        0,
-                    )?;
-
-                    // 5. Reset last saved block number by event watcher.
-                    //    Relayer will restart syncing from block number contract was deployed at.
                     tracing::warn!(
-                        "Reset block number to contract deployed at...!"
+                        expected_root = ?root,
+                        "Invalid merkle root. Maybe invalid leaf or commitment"
                     );
-                    self.storage.set_last_block_number(
-                        history_store_key,
-                        wrapper.config.common.deployed_at,
-                    )?;
+                    // TODO: take a snapshot of current state and restart syncing events
+                    // FIXME: We should restart syncing events
                     // Do not handle this event
                     return Ok(false);
                 }
@@ -172,11 +183,10 @@ impl EventHandler for VAnchorLeavesHandler {
                 let commitment: [u8; 32] = deposit.commitment.into();
                 let leaf_index = deposit.leaf_index.as_u32();
                 let value = (leaf_index, commitment.to_vec());
-                let chain_id = wrapper.contract.client().get_chainid().await?;
                 let target_system = TargetSystem::new_contract_address(
                     wrapper.contract.address().to_fixed_bytes(),
                 );
-                let typed_chain_id = TypedChainId::Evm(chain_id.as_u32());
+                let typed_chain_id = TypedChainId::Evm(self.chain_id.as_u32());
                 let history_store_key =
                     ResourceId::new(target_system, typed_chain_id);
                 store.insert_leaves(history_store_key, &[value.clone()])?;
@@ -196,7 +206,7 @@ impl EventHandler for VAnchorLeavesHandler {
                     kind = %webb_relayer_utils::probe::Kind::LeavesStore,
                     leaf_index = %value.0,
                     leaf = %hex::encode(value.1),
-                    chain_id = %chain_id,
+                    chain_id = %self.chain_id,
                     block_number = %log.block_number
                 );
             }

--- a/flake.nix
+++ b/flake.nix
@@ -55,8 +55,11 @@
             cd $ROOT/tests && pipx run dvc pull
             cd $ROOT
           '';
+
+          # Environment variables
+          RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+          # Needed for running DKG/Tangle locally
+          LD_LIBRARY_PATH = "${pkgs.gmp}/lib";
         };
-        # Environment variables
-        RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
       });
 }

--- a/services/block-poller/src/main.rs
+++ b/services/block-poller/src/main.rs
@@ -36,8 +36,7 @@ pub async fn ignite(
         }
         let chain_name = &chain_config.name;
         let chain_id = U256::from(chain_config.chain_id);
-        let provider = ctx.evm_provider(&chain_id.to_string()).await?;
-        let client = Arc::new(provider);
+        let client = ctx.evm_provider(chain_id).await?;
         tracing::debug!(
             "Starting Background Services for ({}) chain. ({:?})",
             chain_name,

--- a/services/webb-relayer/src/service/evm.rs
+++ b/services/webb-relayer/src/service/evm.rs
@@ -75,8 +75,7 @@ pub async fn ignite(
         }
         let chain_name = &chain_config.name;
         let chain_id = chain_config.chain_id;
-        let provider = ctx.evm_provider(&chain_id.to_string()).await?;
-        let client = Arc::new(provider);
+        let client = ctx.evm_provider(chain_id).await?;
         tracing::debug!(
             "Starting Background Services for ({}) chain.",
             chain_name
@@ -118,7 +117,7 @@ pub async fn ignite(
         // start the transaction queue after starting other tasks.
         start_tx_queue(
             ctx.clone(),
-            chain_config.chain_id.to_string().clone(),
+            chain_config.chain_id,
             store.clone(),
         )?;
     }
@@ -510,7 +509,7 @@ pub async fn start_signature_bridge_events_watcher(
 /// * `store` -[Sled](https://sled.rs)-based database store
 pub fn start_tx_queue(
     ctx: RelayerContext,
-    chain_id: String,
+    chain_id: u32,
     store: Arc<super::Store>,
 ) -> crate::Result<()> {
     // Start tx_queue only when governance relaying feature is enabled for relayer.
@@ -520,7 +519,7 @@ pub fn start_tx_queue(
     }
 
     let mut shutdown_signal = ctx.shutdown_signal();
-    let tx_queue = TxQueue::new(ctx, chain_id.clone(), store);
+    let tx_queue = TxQueue::new(ctx, chain_id.into(), store);
 
     tracing::debug!("Transaction Queue for ({}) Started.", chain_id);
     let task = async move {

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -775,26 +775,26 @@ type NetworkMessage = {
   kind: 'network';
 } & {
   network:
-  | 'connecting'
-  | 'connected'
-  | { failed: { reason: string } }
-  | 'disconnected'
-  | 'unsupportedContract'
-  | 'unsupportedChain'
-  | 'invalidRelayerAddress';
+    | 'connecting'
+    | 'connected'
+    | { failed: { reason: string } }
+    | 'disconnected'
+    | 'unsupportedContract'
+    | 'unsupportedChain'
+    | 'invalidRelayerAddress';
 };
 
 type WithdrawMessage = {
   kind: 'withdraw';
 } & {
   withdraw:
-  | 'sent'
-  | { submitted: { txHash: string } }
-  | { finalized: { txHash: string } }
-  | 'valid'
-  | 'invalidMerkleRoots'
-  | 'droppedFromMemPool'
-  | { errored: { code: number; reason: string } };
+    | 'sent'
+    | { submitted: { txHash: string } }
+    | { finalized: { txHash: string } }
+    | 'valid'
+    | 'invalidMerkleRoots'
+    | 'droppedFromMemPool'
+    | { errored: { code: number; reason: string } };
 };
 
 type ErrorMessage = {

--- a/tests/test/evm/invalidProviders.test.ts
+++ b/tests/test/evm/invalidProviders.test.ts
@@ -63,12 +63,12 @@ class RateLimitedProvider extends InvalidProvider {
 }
 
 describe('Invalid EVM Providers', () => {
-  describe('Rate Limited Provider', function() {
+  describe('Rate Limited Provider', function () {
     const tmpDirPath = temp.mkdirSync();
     let provider: RateLimitedProvider;
     let webbRelayer: WebbRelayer;
 
-    before(async function() {
+    before(async function () {
       this.timeout(0);
       provider = new RateLimitedProvider(await getPort());
 
@@ -116,7 +116,7 @@ describe('Invalid EVM Providers', () => {
       });
     });
 
-    it('should keep retrying with the rate limited provider', async function() {
+    it('should keep retrying with the rate limited provider', async function () {
       await webbRelayer.waitForEvent({
         kind: 'retry',
         event: {

--- a/tests/test/substrate/mixerTransactionRelayer.test.ts
+++ b/tests/test/substrate/mixerTransactionRelayer.test.ts
@@ -1,7 +1,6 @@
 // This our basic Substrate Transaction Relayer Tests.
 // These are for testing the basic relayer functionality. which is just relay transactions for us.
 
-
 import { expect } from 'chai';
 import getPort, { portNumbers } from 'get-port';
 import temp from 'temp';
@@ -25,7 +24,7 @@ import { LocalTangle } from '../../lib/localTangle.js';
 import { createAccount } from '../../lib/utils.js';
 
 // we are going to remove support for Substrate mixer
-describe.skip("Substrate Mixer Transaction Relayer", function () {
+describe.skip('Substrate Mixer Transaction Relayer', function () {
   const tmpDirPath = temp.mkdirSync();
   let aliceNode: LocalTangle;
   let charlieNode: LocalTangle;
@@ -34,9 +33,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
 
   before(async () => {
     const usageMode: UsageMode = isCi
-      ? { mode: "docker", forcePullImage: false }
+      ? { mode: 'docker', forcePullImage: false }
       : {
-          mode: "host",
+          mode: 'host',
           nodePath: path.resolve(
             '../../tangle/target/release/tangle-standalone'
           ),
@@ -46,14 +45,14 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
       name: 'substrate-alice',
       authority: 'alice',
       usageMode,
-      ports: "auto",
+      ports: 'auto',
     });
 
     charlieNode = await LocalTangle.start({
       name: 'substrate-charlie',
       authority: 'charlie',
       usageMode,
-      ports: "auto",
+      ports: 'auto',
     });
 
     // Wait until we are ready and connected
@@ -63,7 +62,7 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     const chainId = await aliceNode.getChainId();
 
     await aliceNode.writeConfig(`${tmpDirPath}/${aliceNode.name}.json`, {
-      suri: "//Charlie",
+      suri: '//Charlie',
       chainId: chainId,
     });
 
@@ -80,9 +79,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     await webbRelayer.waitUntilReady();
   });
 
-  it("Simple Mixer Transaction", async () => {
+  it('Simple Mixer Transaction', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Dave");
+    const account = createAccount('//Dave');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -112,9 +111,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     });
     // now we wait for relayer to execute transaction.
     await webbRelayer.waitForEvent({
-      kind: "private_tx",
+      kind: 'private_tx',
       event: {
-        ty: "SUBSTRATE",
+        ty: 'SUBSTRATE',
         chain_id: chainId.toString(),
         finalized: true,
       },
@@ -128,9 +127,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     expect(balanceAfterWithdraw > initialBalance);
   });
 
-  it("Should fail to withdraw if recipient address is invalid", async () => {
+  it('Should fail to withdraw if recipient address is invalid', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Dave");
+    const account = createAccount('//Dave');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -139,7 +138,7 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
       note
     );
 
-    const invalidAddress = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";
+    const invalidAddress = '5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy';
     // get chainId
     const chainId = await aliceNode.getChainId();
     // now we need to submit the withdrawal transaction.
@@ -161,14 +160,14 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
       expect(e).to.not.be.null;
       // Runtime Error that indicates invalid withdrawal proof
       expect(e).to.contain(
-        "Runtime error: RuntimeError(Module { index: 40, error: 1 }"
+        'Runtime error: RuntimeError(Module { index: 40, error: 1 }'
       );
     }
   });
 
-  it("Should fail to withdraw if proof is invalid", async () => {
+  it('Should fail to withdraw if proof is invalid', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Eve");
+    const account = createAccount('//Eve');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -208,15 +207,15 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
 
       // Runtime Error that indicates VerifyError in pallet-verifier, or InvalidWithdrawProof in pallet-mixer
       const correctErrorMessage =
-        errorMessage.includes("Module { index: 35, error: 1 }") ||
-        errorMessage.includes("Module { index: 40, error: 1 }");
+        errorMessage.includes('Module { index: 35, error: 1 }') ||
+        errorMessage.includes('Module { index: 40, error: 1 }');
       expect(correctErrorMessage);
     }
   });
 
-  it("Should fail to withdraw if fee is not expected", async () => {
+  it('Should fail to withdraw if fee is not expected', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Ferdie");
+    const account = createAccount('//Ferdie');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -250,9 +249,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     }
   });
 
-  it("Should fail to withdraw with invalid root", async () => {
+  it('Should fail to withdraw with invalid root', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Eve");
+    const account = createAccount('//Eve');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -293,9 +292,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     }
   });
 
-  it("Should fail to withdraw if recipient address is invalid", async () => {
+  it('Should fail to withdraw if recipient address is invalid', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Dave");
+    const account = createAccount('//Dave');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -304,7 +303,7 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
       note
     );
 
-    const invalidAddress = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";
+    const invalidAddress = '5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy';
     // get chainId
     const chainId = await aliceNode.getChainId();
     // now we need to submit the withdrawal transaction.
@@ -329,9 +328,9 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
     }
   });
 
-  it("Should fail to withdraw with invalid nullifier hash", async () => {
+  it('Should fail to withdraw with invalid nullifier hash', async () => {
     const api = await aliceNode.api();
-    const account = createAccount("//Eve");
+    const account = createAccount('//Eve');
     const note = await makeDeposit(api, aliceNode, account);
     const withdrawalProof = await initWithdrawal(
       api,
@@ -382,24 +381,24 @@ describe.skip("Substrate Mixer Transaction Relayer", function () {
 // Helper methods, we can move them somewhere if we end up using them again.
 
 async function createMixerDepositTx(api: ApiPromise): Promise<{
-  tx: SubmittableExtrinsic<"promise">;
+  tx: SubmittableExtrinsic<'promise'>;
   note: Note;
 }> {
   const noteInput: NoteGenInput = {
-    protocol: "mixer",
-    version: "v2",
-    sourceChain: "5",
-    targetChain: "5",
-    sourceIdentifyingData: "3",
-    targetIdentifyingData: "3",
-    tokenSymbol: "WEBB",
-    amount: "1",
-    denomination: "18",
-    backend: "Arkworks",
-    hashFunction: "Poseidon",
-    curve: "Bn254",
-    width: "3",
-    exponentiation: "5",
+    protocol: 'mixer',
+    version: 'v2',
+    sourceChain: '5',
+    targetChain: '5',
+    sourceIdentifyingData: '3',
+    targetIdentifyingData: '3',
+    tokenSymbol: 'WEBB',
+    amount: '1',
+    denomination: '18',
+    backend: 'Arkworks',
+    hashFunction: 'Poseidon',
+    curve: 'Bn254',
+    width: '3',
+    exponentiation: '5',
   };
   const note = await Note.generateNote(noteInput);
   const treeId = 0;
@@ -433,12 +432,12 @@ async function createMixerWithdrawProof(
 ): Promise<WithdrawalProof> {
   try {
     const recipientAddressHex = u8aToHex(decodeAddress(opts.recipient)).replace(
-      "0x",
-      ""
+      '0x',
+      ''
     );
     const relayerAddressHex = u8aToHex(decodeAddress(opts.relayer)).replace(
-      "0x",
-      ""
+      '0x',
+      ''
     );
     const treeId = 0;
     const leafCount: number =
@@ -458,21 +457,21 @@ async function createMixerWithdrawProof(
     const leafIndex = treeLeaves.findIndex((l) => u8aToHex(l) === leafHex);
     expect(leafIndex).to.be.greaterThan(-1);
     const gitRoot = child
-      .execSync("git rev-parse --show-toplevel")
+      .execSync('git rev-parse --show-toplevel')
       .toString()
       .trim();
     const provingKeyPath = path.join(
       gitRoot,
-      "tests",
-      "substrate-fixtures",
-      "mixer",
-      "bn254",
-      "x5",
-      "proving_key_uncompressed.bin"
+      'tests',
+      'substrate-fixtures',
+      'mixer',
+      'bn254',
+      'x5',
+      'proving_key_uncompressed.bin'
     );
     const provingKey = fs.readFileSync(provingKeyPath);
 
-    const proofInput: ProvingManagerSetupInput<"mixer"> = {
+    const proofInput: ProvingManagerSetupInput<'mixer'> = {
       note: note.serialize(),
       relayer: relayerAddressHex,
       recipient: recipientAddressHex,
@@ -482,7 +481,7 @@ async function createMixerWithdrawProof(
       refund: opts.refund === undefined ? 0 : opts.refund,
       provingKey,
     };
-    const zkProof = await provingManager.prove("mixer", proofInput);
+    const zkProof = await provingManager.prove('mixer', proofInput);
     return {
       id: treeId,
       proofBytes: `0x${zkProof.proof}`,

--- a/tests/test/substrate/vanchorTransactionRelayer.test.ts
+++ b/tests/test/substrate/vanchorTransactionRelayer.test.ts
@@ -273,7 +273,7 @@ describe('Substrate VAnchor Transaction Relayer Tests', function () {
       '44' // pallet Id
     );
     expect(response.status).equal(200);
-    const leavesStore = await response.json() as LeavesCacheResponse;
+    const leavesStore = (await response.json()) as LeavesCacheResponse;
     expect(indexBeforeInsetion + 2).to.equal(leavesStore.leaves.length);
   });
 


### PR DESCRIPTION
## Highlights of this PR

- [Use of the cached `chain_id` when possible instead of refetching it](https://github.com/webb-tools/relayer/commit/3622570f066696682175d7d4385659fbedceaa5a)
previously, we used to call `eth_chainId` on every block/event iterations, we do not need this at all, we can cache it or pass it to the service that needs it.
- [Make the default `max_blocks_per_step` is `500` blocks/step](https://github.com/webb-tools/relayer/commit/75e821ff853bd73d320248fda701ea0fab7b2ffb)
This should make the initial sync faster by default (you still can override it from the config)
- [Correctly build the merkle tree in the leaves handler](https://github.com/webb-tools/relayer/commit/6ee7412c53ca1a6691ea1ae774363d371ee6ee5c)
There was a bug where when we start back up, we do not initialize the merkle tree with the saved leaves.
- [Cache the EVM Providers instead of creating ones every single time](https://github.com/webb-tools/relayer/commit/17dc90c56c1ae8ba122b91abe505f2370eab37bc)
Everytime we call `evm_provider` we were creating a new connection to the RPC node, now we can cache these instead.
- [Change the way we return the cached leaves](https://github.com/webb-tools/relayer/commit/3331605f628142277a040747c7dce6bd7744dce6)
It is now retruning as a `leaf_index -> leaf_bytes`. However, this does not affect the public leaves API (so no breaking changes).
- [Do not fetch the chainId nor the latest block number when not needed](https://github.com/webb-tools/relayer/commit/e0b0340f1da39537cd6df635919f4a95a752d0c1)
This a minor optimization, where we first check if we can handle this event or not, before featching the latest block number to check if we are syncing or not. There is a room to even optmize this more.
- [Optmize the way we fetch events.](https://github.com/webb-tools/relayer/commit/b4e84bdf611f1be82237956b1d1c9520b36ea448) 
**This mostly the biggest changes here, So I'm going to explain it as detailed as possible**:

**TL;DR version**: The new implementation offers better performance and reliability by reducing the load on system resources and ensuring synchronization with the latest block.

**The Long version**: The previous implementation was inefficient as it needlessly consumed a lot of resources. It performed a fetch of the last block number at each iteration, calculated the destination block number, and then fetched the events. The process continued in a loop without a cooldown until the latest block was reached. The system heavily relied on this process, which caused a significant drain on resources.

To remedy this issue, the new implementation fetches the last block number once and never updates it until it is fully synchronized with the latest block. This new implementation allows us to fetch the events in fewer calls without constant polling until the latest block is reached. Only then can we confirm that the system is fully synchronized. Until this point, the system only updates the latest block, making it more efficient in its resource utilization.

It is important to note that with the new implementation, fetching the latest block is no longer in a hot loop. This is because the system only fetches it after a `polling interval` of milliseconds. This makes the system more efficient and reduces the load on the resources.

Overall, the new implementation is significantly more efficient and reliable than the previous one. It allows for a better use of system resources and ensures that the system stays synchronized with the latest block.


-----
### Code Checklist 

- [x] Tested
- [x] Documented
