### PR TITLE
Fix partial writes

### DIFF
--- a/crates/relayer-store/src/lib.rs
+++ b/crates/relayer-store/src/lib.rs
@@ -285,13 +285,6 @@ pub trait LeafCacheStore: HistoryStore {
         range: core::ops::Range<u32>,
     ) -> crate::Result<Self::Output>;
 
-    /// Insert the leaves for the given key.
-    fn insert_leaves<K: Into<HistoryStoreKey> + Debug>(
-        &self,
-        key: K,
-        leaves: &[(u32, Vec<u8>)],
-    ) -> crate::Result<()>;
-
     /// The last deposit info is sent to the client on leaf request
     /// So they can verify when the last transaction was sent to maintain
     /// their own state of mixers.
@@ -300,16 +293,9 @@ pub trait LeafCacheStore: HistoryStore {
         key: K,
     ) -> crate::Result<u64>;
 
-    /// Set the last deposit block number for the given key.
-    fn insert_last_deposit_block_number<K: Into<HistoryStoreKey> + Debug>(
-        &self,
-        key: K,
-        block_number: u64,
-    ) -> crate::Result<u64>;
-
     /// Insert leaves and last deposit block number for the given key.
     fn insert_leaves_and_last_deposit_block_number<
-        K: Into<HistoryStoreKey> + Debug,
+        K: Into<HistoryStoreKey> + Debug + Clone,
     >(
         &self,
         key: K,
@@ -337,13 +323,6 @@ pub trait EncryptedOutputCacheStore: HistoryStore {
         range: core::ops::Range<u32>,
     ) -> crate::Result<Self::Output>;
 
-    /// Insert the encrypted output for the given key.
-    fn insert_encrypted_output<K: Into<HistoryStoreKey> + Debug>(
-        &self,
-        key: K,
-        encrypted_output: &[(u32, Vec<u8>)],
-    ) -> crate::Result<()>;
-
     /// The last deposit info is sent to the client on encrypted_output request
     /// So they can verify when the last transaction was sent to maintain
     /// their own state of mixers.
@@ -354,18 +333,9 @@ pub trait EncryptedOutputCacheStore: HistoryStore {
         key: K,
     ) -> crate::Result<u64>;
 
-    /// Set the last deposit block number for the given key.
-    fn insert_last_deposit_block_number_for_encrypted_output<
-        K: Into<HistoryStoreKey> + Debug,
-    >(
-        &self,
-        key: K,
-        block_number: u64,
-    ) -> crate::Result<u64>;
-
     /// Insert encrypted output and last deposit block number for the given key.
     fn insert_encrypted_output_and_last_deposit_block_number<
-        K: Into<HistoryStoreKey> + Debug,
+        K: Into<HistoryStoreKey> + Debug + Clone,
     >(
         &self,
         key: K,

--- a/crates/relayer-store/src/lib.rs
+++ b/crates/relayer-store/src/lib.rs
@@ -306,6 +306,16 @@ pub trait LeafCacheStore: HistoryStore {
         key: K,
         block_number: u64,
     ) -> crate::Result<u64>;
+
+    /// Insert leaves and last deposit block number for the given key.
+    fn insert_leaves_and_last_deposit_block_number<
+        K: Into<HistoryStoreKey> + Debug,
+    >(
+        &self,
+        key: K,
+        leaves: &[(u32, Vec<u8>)],
+        block_number: u64,
+    ) -> crate::Result<()>;
 }
 
 /// An Encrypted Output Cache Store is a simple trait that would help in
@@ -352,6 +362,16 @@ pub trait EncryptedOutputCacheStore: HistoryStore {
         key: K,
         block_number: u64,
     ) -> crate::Result<u64>;
+
+    /// Insert encrypted output and last deposit block number for the given key.
+    fn insert_encrypted_output_and_last_deposit_block_number<
+        K: Into<HistoryStoreKey> + Debug,
+    >(
+        &self,
+        key: K,
+        encrypted_output: &[(u32, Vec<u8>)],
+        block_number: u64,
+    ) -> crate::Result<()>;
 }
 
 /// A Command sent to the Bridge to execute different actions.

--- a/crates/relayer-store/src/mem.rs
+++ b/crates/relayer-store/src/mem.rs
@@ -193,7 +193,7 @@ impl LeafCacheStore for InMemoryStore {
             // 2. Insert last deposit block number
             guard2.insert(key.clone().into(), block_number);
             // 3. Insert last block number
-            guard3.entry(key.clone().into()).or_insert(block_number);
+            guard3.entry(key.into()).or_insert(block_number);
         }
         Ok(())
     }
@@ -265,7 +265,7 @@ impl EncryptedOutputCacheStore for InMemoryStore {
                 .or_insert_with(|| {
                     encrypted_outputs.iter().map(|v| v.1.clone()).collect()
                 });
-            guard2.insert(key.clone().into(), block_number);
+            guard2.insert(key.into(), block_number);
         }
         Ok(())
     }

--- a/crates/relayer-store/src/mem.rs
+++ b/crates/relayer-store/src/mem.rs
@@ -185,6 +185,18 @@ impl LeafCacheStore for InMemoryStore {
     ) -> crate::Result<u64> {
         Ok(0u64)
     }
+
+    #[tracing::instrument(skip(self))]
+    fn insert_leaves_and_last_deposit_block_number<
+        K: Into<HistoryStoreKey> + Debug,
+    >(
+        &self,
+        key: K,
+        leaves: &[(u32, Vec<u8>)],
+        block_number: u64,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
 }
 
 impl EncryptedOutputCacheStore for InMemoryStore {
@@ -254,6 +266,17 @@ impl EncryptedOutputCacheStore for InMemoryStore {
         block_number: u64,
     ) -> crate::Result<u64> {
         Ok(0u64)
+    }
+    #[tracing::instrument(skip(self))]
+    fn insert_encrypted_output_and_last_deposit_block_number<
+        K: Into<HistoryStoreKey> + Debug,
+    >(
+        &self,
+        key: K,
+        encrypted_outputs: &[(u32, Vec<u8>)],
+        block_number: u64,
+    ) -> crate::Result<()> {
+        Ok(())
     }
 }
 

--- a/crates/relayer-store/src/mem.rs
+++ b/crates/relayer-store/src/mem.rs
@@ -36,6 +36,9 @@ pub struct InMemoryStore {
     store_for_map: Arc<RwLock<MemStoreForMap>>,
     last_block_numbers: Arc<RwLock<HashMap<HistoryStoreKey, u64>>>,
     target_block_numbers: Arc<RwLock<HashMap<HistoryStoreKey, u64>>>,
+    last_deposit_block_numbers: Arc<RwLock<HashMap<HistoryStoreKey, u64>>>,
+    encrypted_output_last_deposit_block_numbers:
+        Arc<RwLock<HashMap<HistoryStoreKey, u64>>>,
     token_prices_cache: Arc<RwLock<HashMap<String, Vec<u8>>>>,
 }
 
@@ -146,55 +149,52 @@ impl LeafCacheStore for InMemoryStore {
     }
 
     #[tracing::instrument(skip(self))]
-    fn insert_leaves<K: Into<HistoryStoreKey> + Debug>(
-        &self,
-        key: K,
-        leaves: &[(u32, Vec<u8>)],
-    ) -> crate::Result<()> {
-        let mut guard = self.store_for_map.write();
-        guard
-            .entry(key.into())
-            .and_modify(|v| {
-                for (index, leaf) in leaves {
-                    v.insert(*index, types::H256::from_slice(leaf));
-                }
-            })
-            .or_insert_with(|| {
-                let mut map = BTreeMap::new();
-                for (index, leaf) in leaves {
-                    map.insert(*index, types::H256::from_slice(leaf));
-                }
-                map
-            });
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self))]
     fn get_last_deposit_block_number<K: Into<HistoryStoreKey> + Debug>(
         &self,
         key: K,
     ) -> crate::Result<u64> {
-        Ok(0u64)
-    }
-
-    #[tracing::instrument(skip(self))]
-    fn insert_last_deposit_block_number<K: Into<HistoryStoreKey> + Debug>(
-        &self,
-        key: K,
-        block_number: u64,
-    ) -> crate::Result<u64> {
-        Ok(0u64)
+        let guard = self.last_deposit_block_numbers.read();
+        let default_block_number = 0u64;
+        let val = guard
+            .get(&key.into())
+            .cloned()
+            .unwrap_or(default_block_number);
+        Ok(val)
     }
 
     #[tracing::instrument(skip(self))]
     fn insert_leaves_and_last_deposit_block_number<
-        K: Into<HistoryStoreKey> + Debug,
+        K: Into<HistoryStoreKey> + Debug + Clone,
     >(
         &self,
         key: K,
         leaves: &[(u32, Vec<u8>)],
         block_number: u64,
     ) -> crate::Result<()> {
+        let mut guard1 = self.store_for_map.write();
+        let mut guard2 = self.last_deposit_block_numbers.write();
+        let mut guard3 = self.last_block_numbers.write();
+        {
+            // 1. Insert leaves
+            guard1
+                .entry(key.clone().into())
+                .and_modify(|v| {
+                    for (index, leaf) in leaves {
+                        v.insert(*index, types::H256::from_slice(leaf));
+                    }
+                })
+                .or_insert_with(|| {
+                    let mut map = BTreeMap::new();
+                    for (index, leaf) in leaves {
+                        map.insert(*index, types::H256::from_slice(leaf));
+                    }
+                    map
+                });
+            // 2. Insert last deposit block number
+            guard2.insert(key.clone().into(), block_number);
+            // 3. Insert last block number
+            guard3.entry(key.clone().into()).or_insert(block_number);
+        }
         Ok(())
     }
 }
@@ -228,54 +228,45 @@ impl EncryptedOutputCacheStore for InMemoryStore {
     }
 
     #[tracing::instrument(skip(self))]
-    fn insert_encrypted_output<K: Into<HistoryStoreKey> + Debug>(
-        &self,
-        key: K,
-        encrypted_outputs: &[(u32, Vec<u8>)],
-    ) -> crate::Result<()> {
-        let mut guard = self.store_for_vec.write();
-        guard
-            .entry(key.into())
-            .and_modify(|v| {
-                for (index, encrypted_output) in encrypted_outputs {
-                    v.insert(*index as usize, encrypted_output.clone());
-                }
-            })
-            .or_insert_with(|| {
-                encrypted_outputs.iter().map(|v| v.1.clone()).collect()
-            });
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self))]
     fn get_last_deposit_block_number_for_encrypted_output<
         K: Into<HistoryStoreKey> + Debug,
     >(
         &self,
         key: K,
     ) -> crate::Result<u64> {
-        Ok(0u64)
+        let guard = self.encrypted_output_last_deposit_block_numbers.read();
+        let default_block_number = 0u64;
+        let val = guard
+            .get(&key.into())
+            .cloned()
+            .unwrap_or(default_block_number);
+        Ok(val)
     }
 
     #[tracing::instrument(skip(self))]
-    fn insert_last_deposit_block_number_for_encrypted_output<
-        K: Into<HistoryStoreKey> + Debug,
-    >(
-        &self,
-        key: K,
-        block_number: u64,
-    ) -> crate::Result<u64> {
-        Ok(0u64)
-    }
-    #[tracing::instrument(skip(self))]
     fn insert_encrypted_output_and_last_deposit_block_number<
-        K: Into<HistoryStoreKey> + Debug,
+        K: Into<HistoryStoreKey> + Debug + Clone,
     >(
         &self,
         key: K,
         encrypted_outputs: &[(u32, Vec<u8>)],
         block_number: u64,
     ) -> crate::Result<()> {
+        let mut guard1 = self.store_for_vec.write();
+        let mut guard2 = self.last_deposit_block_numbers.write();
+        {
+            guard1
+                .entry(key.clone().into())
+                .and_modify(|v| {
+                    for (index, encrypted_output) in encrypted_outputs {
+                        v.insert(*index as usize, encrypted_output.clone());
+                    }
+                })
+                .or_insert_with(|| {
+                    encrypted_outputs.iter().map(|v| v.1.clone()).collect()
+                });
+            guard2.insert(key.clone().into(), block_number);
+        }
         Ok(())
     }
 }
@@ -312,7 +303,14 @@ mod tests {
             .map(|i| (i, types::H256::random().to_fixed_bytes().to_vec()))
             .collect::<Vec<_>>();
         let key = HistoryStoreKey::from(1u32);
-        store.insert_leaves(key, &generated_leaves).unwrap();
+        let block_number = 20u64;
+        store
+            .insert_leaves_and_last_deposit_block_number(
+                key,
+                &generated_leaves,
+                block_number,
+            )
+            .unwrap();
         let leaves = store.get_leaves(key).unwrap();
         assert_eq!(
             leaves
@@ -334,7 +332,14 @@ mod tests {
             .map(|i| (i, types::H256::random().to_fixed_bytes().to_vec()))
             .collect::<Vec<_>>();
         let key = HistoryStoreKey::from(1u32);
-        store.insert_leaves(key, &generated_leaves).unwrap();
+        let block_number = 20u64;
+        store
+            .insert_leaves_and_last_deposit_block_number(
+                key,
+                &generated_leaves,
+                block_number,
+            )
+            .unwrap();
         let leaves = store.get_leaves_with_range(key, 5..10).unwrap();
         assert_eq!(
             leaves
@@ -348,5 +353,37 @@ mod tests {
                 .map(|v| v.1.clone())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn insert_leaves_and_last_deposit_block_number() {
+        // a simple test to show that we can get all the leaves that we inserted.
+        let store = InMemoryStore::default();
+        let generated_leaves = (0..20u32)
+            .map(|i| (i, types::H256::random().to_fixed_bytes().to_vec()))
+            .collect::<Vec<_>>();
+        let key = HistoryStoreKey::from(1u32);
+        let block_number = 20u64;
+        store
+            .insert_leaves_and_last_deposit_block_number(
+                key,
+                &generated_leaves,
+                block_number,
+            )
+            .unwrap();
+        let last_deposit_block_number =
+            store.get_last_deposit_block_number(key).unwrap();
+        assert_eq!(last_deposit_block_number, block_number);
+        let leaves = store.get_leaves(key).unwrap();
+        assert!(leaves
+            .into_iter()
+            .map(|v| v.1.to_fixed_bytes().to_vec())
+            .collect::<Vec<_>>()
+            .iter()
+            .eq(generated_leaves
+                .iter()
+                .map(|v| v.1.clone())
+                .collect::<Vec<_>>()
+                .iter()));
     }
 }

--- a/crates/relayer-utils/src/lib.rs
+++ b/crates/relayer-utils/src/lib.rs
@@ -199,6 +199,9 @@ pub enum Error {
     ReadSubstrateStorageError,
     #[error("Cannot convert default leaf scalar into bytes")]
     ConvertLeafScalarError,
+    /// Invalid Merkle root
+    #[error("Invalid Merkle root at index {}", _0)]
+    InvalidMerkleRootError(u32),
 }
 
 /// A type alias for the result for webb relayer, that uses the `Error` enum.

--- a/event-watchers/evm/src/open_vanchor/open_vanchor_leaves_handler.rs
+++ b/event-watchers/evm/src/open_vanchor/open_vanchor_leaves_handler.rs
@@ -21,8 +21,8 @@ use webb::evm::ethers::prelude::{LogMeta, Middleware};
 use webb_event_watcher_traits::evm::EventHandler;
 use webb_event_watcher_traits::EthersClient;
 use webb_proposals::{ResourceId, TargetSystem, TypedChainId};
-use webb_relayer_store::SledStore;
-use webb_relayer_store::{EventHashStore, LeafCacheStore};
+use webb_relayer_store::EventHashStore;
+use webb_relayer_store::{LeafCacheStore, SledStore};
 use webb_relayer_utils::metric;
 /// An VAnchor Leaves Handler that handles `NewCommitment` events and saves the leaves to the store.
 /// It serves as a cache for leaves that could be used by dApp for proof generation.
@@ -68,9 +68,9 @@ impl EventHandler for OpenVAnchorLeavesHandler {
                 let typed_chain_id = TypedChainId::Evm(chain_id.as_u32());
                 let history_store_key =
                     ResourceId::new(target_system, typed_chain_id);
-                store.insert_leaves(history_store_key, &[value.clone()])?;
-                store.insert_last_deposit_block_number(
+                store.insert_leaves_and_last_deposit_block_number(
                     history_store_key,
+                    &[value.clone()],
                     log.block_number.as_u64(),
                 )?;
                 let events_bytes = serde_json::to_vec(&deposit)?;

--- a/event-watchers/evm/src/vanchor/vanchor_encrypted_outputs_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_encrypted_outputs_handler.rs
@@ -78,12 +78,10 @@ impl EventHandler for VAnchorEncryptedOutputHandler {
                 let typed_chain_id = TypedChainId::Evm(self.chain_id.as_u32());
                 let history_store_key =
                     ResourceId::new(target_system, typed_chain_id);
-                store.insert_encrypted_output(
+
+                store.insert_encrypted_output_and_last_deposit_block_number(
                     history_store_key,
                     &[value.clone()],
-                )?;
-                store.insert_last_deposit_block_number_for_encrypted_output(
-                    history_store_key,
                     log.block_number.as_u64(),
                 )?;
                 let events_bytes = serde_json::to_vec(&deposit)?;

--- a/event-watchers/evm/src/vanchor/vanchor_leaves_handler.rs
+++ b/event-watchers/evm/src/vanchor/vanchor_leaves_handler.rs
@@ -177,10 +177,10 @@ impl EventHandler for VAnchorLeavesHandler {
                     // TODO: take a snapshot of current state and restart syncing events
                     // FIXME: We should restart syncing events
                 }
-                // 2. We will insert leaf into store
-                store.insert_leaves(history_store_key, &[value.clone()])?;
-                store.insert_last_deposit_block_number(
+                // 2. We will insert leaf and last deposit block number into store
+                store.insert_leaves_and_last_deposit_block_number(
                     history_store_key,
+                    &[value.clone()],
                     log.block_number.as_u64(),
                 )?;
                 let events_bytes = serde_json::to_vec(&event_data)?;

--- a/event-watchers/substrate/src/vanchor_encrypted_output_handler.rs
+++ b/event-watchers/substrate/src/vanchor_encrypted_output_handler.rs
@@ -101,9 +101,9 @@ impl EventHandler<PolkadotConfig> for SubstrateVAnchorEncryptedOutputHandler {
                 [event.encrypted_output1, event.encrypted_output2]
             {
                 let value = (index, encrypted_output.clone());
-                store.insert_encrypted_output(history_store_key, &[value])?;
-                store.insert_last_deposit_block_number_for_encrypted_output(
+                store.insert_encrypted_output_and_last_deposit_block_number(
                     history_store_key,
+                    &[value],
                     block_number,
                 )?;
                 index += 1;

--- a/event-watchers/substrate/src/vanchor_leaves_handler.rs
+++ b/event-watchers/substrate/src/vanchor_leaves_handler.rs
@@ -94,9 +94,9 @@ impl EventHandler<PolkadotConfig> for SubstrateVAnchorLeavesHandler {
             let mut leaf_store = Vec::with_capacity(leaf_count);
             for leaf in event.leafs {
                 let value = (leaf_index, leaf.0.to_vec());
-                store.insert_leaves(history_store_key, &[value])?;
-                store.insert_last_deposit_block_number(
+                store.insert_leaves_and_last_deposit_block_number(
                     history_store_key,
+                    &[value],
                     block_number,
                 )?;
                 leaf_index += 1;


### PR DESCRIPTION
## Summary of changes
- Fix partial write issue with computing Merkle root in `can_handle_evensts`, moved it to `handle_events`
- Group operation for LeafStoreCache traits using sled atomic transactions
https://docs.rs/sled/latest/sled/transaction/index.html

```rust
store.insert_leaves()
// This is the last deposit event block number
store.insert_last_deposit_block_number()
// This will be used by the event watcher to track the block number that has been processed
store.set_last_block_number()
```


### Reference issue to close (if applicable)
- Closes #506 

-----
### Code Checklist 

- [x] Tested
- [ ] Documented
