### PR TITLE
Multiple Rpc support for Evm chains

### DIFF
--- a/config/block-header-relay/eth2-networks/ethereum-mainnet.toml
+++ b/config/block-header-relay/eth2-networks/ethereum-mainnet.toml
@@ -2,8 +2,8 @@
 enabled = false
 # The name that the chain is indexed on, for linkable anchors
 name = "ethereum-mainnet"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$ETHEREUM_MAINNET_HTTP_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$ETHEREUM_MAINNET_HTTP_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$ETHEREUM_MAINNET_WS_URL"
 # chain specific id from evm opcode

--- a/config/block-header-relay/eth2-networks/goerli.toml
+++ b/config/block-header-relay/eth2-networks/goerli.toml
@@ -2,8 +2,8 @@
 enabled = true
 # The name that the chain is indexed on, for linkable anchors
 name = "goerli-testnet"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$GOERLI_HTTP_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$GOERLI_HTTP_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$GOERLI_WS_URL"
 # chain specific id from evm opcode

--- a/config/block-header-relay/eth2-networks/sepolia.toml
+++ b/config/block-header-relay/eth2-networks/sepolia.toml
@@ -2,8 +2,8 @@
 enabled = true
 # The name that the chain is indexed on, for linkable anchors
 name = "sepolia-testnet"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$SEPOLIA_HTTP_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$SEPOLIA_HTTP_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$SEPOLIA_WS_URL"
 # chain specific id from evm opcode

--- a/config/development/evm-blanknet/athena.toml
+++ b/config/development/evm-blanknet/athena.toml
@@ -2,8 +2,8 @@
 [evm.athena]
 # The name that the chain is indexed on, for linkable anchors
 name = "athena"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "http://localhost:5002"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["http://localhost:5002"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "ws://localhost:5002"
 # chain specific id from evm opcode

--- a/config/development/evm-blanknet/demeter.toml
+++ b/config/development/evm-blanknet/demeter.toml
@@ -2,8 +2,8 @@
 [evm.demeter]
 # The name that the chain is indexed on, for linkable anchors
 name = "demeter"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "http://localhost:5003"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["http://localhost:5003"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "ws://localhost:5003"
 # chain specific id from evm opcode

--- a/config/development/evm-blanknet/hermes.toml
+++ b/config/development/evm-blanknet/hermes.toml
@@ -2,8 +2,8 @@
 [evm.hermes]
 # The name that the chain is indexed on, for linkable anchors
 name = "hermes"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "http://localhost:5001"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["http://localhost:5001"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "ws://localhost:5001"
 # chain specific id from evm opcode

--- a/config/development/evm-local-tangle/athena.json
+++ b/config/development/evm-local-tangle/athena.json
@@ -2,7 +2,7 @@
   "evm": {
     "athena": {
       "name": "athena",
-      "http-endpoint": "http://localhost:5002",
+      "http-endpoints": ["http://localhost:5002"],
       "ws-endpoint": "ws://localhost:5002",
       "chain-id": 5002,
       "private-key": "$ATHENA_PRIVATE_KEY",

--- a/config/development/evm-local-tangle/demeter.json
+++ b/config/development/evm-local-tangle/demeter.json
@@ -2,7 +2,7 @@
   "evm": {
     "demeter": {
       "name": "demeter",
-      "http-endpoint": "http://localhost:5003",
+      "http-endpoints": ["http://localhost:5003"],
       "ws-endpoint": "ws://localhost:5003",
       "chain-id": 5003,
       "private-key": "$DEMETER_PRIVATE_KEY",

--- a/config/development/evm-local-tangle/hermes.json
+++ b/config/development/evm-local-tangle/hermes.json
@@ -2,7 +2,7 @@
   "evm": {
     "hermes": {
       "name": "hermes",
-      "http-endpoint": "http://localhost:5001",
+      "http-endpoints": ["http://localhost:5001"],
       "ws-endpoint": "ws://localhost:5001",
       "chain-id": 5001,
       "private-key": "$HERMES_PRIVATE_KEY",

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -27,9 +27,9 @@ private-tx-relay = true
 # The following block defines an EVM network (in this case, Goerli) that the relayer will connect to.
 [evm.goerli]
 name = "goerli"
-# Http(s) Endpoint for quick Req/Res
+# Http(s) Endpoints for quick Req/Res
 # env: WEBB_EVM_GOERLI_HTTP_ENDPOINT
-http-endpoint = "https://rpc.ankr.com/eth_goerli"
+http-endpoints = ["https://rpc.ankr.com/eth_goerli"]
 # Websocket Endpoint for long living connections
 # env: WEBB_EVM_GOERLI_WS_ENDPOINT
 ws-endpoint = "wss://rpc.ankr.com/eth_goerli"

--- a/config/exclusive-strategies/data-querying/goerli.toml
+++ b/config/exclusive-strategies/data-querying/goerli.toml
@@ -1,7 +1,7 @@
 [evm.goerli]
 name = "goerli"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$GOERLI_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$GOERLI_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$GOERLI_WSS_URL"
 # Block Explorer

--- a/config/exclusive-strategies/data-querying/sepolia.toml
+++ b/config/exclusive-strategies/data-querying/sepolia.toml
@@ -1,7 +1,7 @@
 [evm.sepolia]
 name = "sepolia"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$SEPOLIA_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$SEPOLIA_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$SEPOLIA_WSS_URL"
 # Block Explorer

--- a/config/exclusive-strategies/private-tx-relaying/goerli.toml
+++ b/config/exclusive-strategies/private-tx-relaying/goerli.toml
@@ -1,8 +1,8 @@
 # Block which represents properties for a network
 [evm.goerli]
 name = "goerli"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$GOERLI_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$GOERLI_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$GOERLI_WSS_URL"
 # Block Explorer

--- a/config/exclusive-strategies/private-tx-relaying/sepolia.toml
+++ b/config/exclusive-strategies/private-tx-relaying/sepolia.toml
@@ -1,8 +1,8 @@
 # Block which represents properties for a network
 [evm.sepolia]
 name = "sepolia"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$SEPOLIA_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$SEPOLIA_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$SEPOLIA_WSS_URL"
 # Block Explorer

--- a/config/exclusive-strategies/signature-relaying/goerli.toml
+++ b/config/exclusive-strategies/signature-relaying/goerli.toml
@@ -1,8 +1,8 @@
 # Block which represents properties for a network
 [evm.goerli]
 name = "goerli"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$GOERLI_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$GOERLI_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$GOERLI_WSS_URL"
 # Block Explorer

--- a/config/exclusive-strategies/signature-relaying/optimism_test.toml
+++ b/config/exclusive-strategies/signature-relaying/optimism_test.toml
@@ -1,8 +1,8 @@
 # Block which represents properties for a network
 [evm.optimismtestnet]
 name = "optimismtestnet"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$OPTIMISM_TESTNET_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$OPTIMISM_TESTNET_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$OPTIMISM_TESTNET_WSS_URL"
 # Block Explorer

--- a/config/exclusive-strategies/signature-relaying/sepolia.toml
+++ b/config/exclusive-strategies/signature-relaying/sepolia.toml
@@ -1,8 +1,8 @@
 # Block which represents properties for a network
 [evm.sepolia]
 name = "sepolia"
-# Http(s) Endpoint for quick Req/Res
-http-endpoint = "$SEPOLIA_HTTPS_URL"
+# Http(s) Endpoints for quick Req/Res
+http-endpoints = ["$SEPOLIA_HTTPS_URL"]
 # Websocket Endpoint for long living connections
 ws-endpoint = "$SEPOLIA_WSS_URL"
 # Block Explorer

--- a/crates/event-watcher-traits/src/evm/event_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/event_watcher.rs
@@ -92,7 +92,21 @@ pub trait EventWatcher {
                 .map_err(backoff::Error::transient)
                 .await?
                 .as_u32();
-            // now we start polling for new events.
+
+            // let chain_id = 5001u32;
+            // let client = ctx.evm_provider(chain_id).await?;
+            // let chain_config =
+            //     ctx.config.evm.get(&chain_id.to_string()).ok_or_else(|| {
+            //     webb_relayer_utils::Error::ChainNotFound {
+            //         chain_id: chain_id.to_string(),
+            //     }
+            // })?;
+
+            // // Time lag offset tip.
+            // let block_confirmations = chain_config.block_confirmations;
+            // let timelag_client =
+            //     Arc::new(TimeLag::new(client.clone(), block_confirmations));
+            // // now we start polling for new events.
             // create history store key
             let src_target_system = TargetSystem::new_contract_address(
                 contract.address().to_fixed_bytes(),

--- a/crates/event-watcher-traits/src/evm/event_watcher.rs
+++ b/crates/event-watcher-traits/src/evm/event_watcher.rs
@@ -92,22 +92,6 @@ pub trait EventWatcher {
                 .map_err(backoff::Error::transient)
                 .await?
                 .as_u32();
-
-            // let chain_id = 5001u32;
-            // let client = ctx.evm_provider(chain_id).await?;
-            // let chain_config =
-            //     ctx.config.evm.get(&chain_id.to_string()).ok_or_else(|| {
-            //     webb_relayer_utils::Error::ChainNotFound {
-            //         chain_id: chain_id.to_string(),
-            //     }
-            // })?;
-
-            // // Time lag offset tip.
-            // let block_confirmations = chain_config.block_confirmations;
-            // let timelag_client =
-            //     Arc::new(TimeLag::new(client.clone(), block_confirmations));
-            // // now we start polling for new events.
-            // create history store key
             let src_target_system = TargetSystem::new_contract_address(
                 contract.address().to_fixed_bytes(),
             );

--- a/crates/relayer-config/src/evm/mod.rs
+++ b/crates/relayer-config/src/evm/mod.rs
@@ -20,7 +20,7 @@ pub struct EvmChainConfig {
     pub enabled: bool,
     /// Http(s) Endpoint for quick Req/Res
     #[serde(skip_serializing)]
-    pub http_endpoint: RpcUrl,
+    pub http_endpoints: Vec<RpcUrl>,
     /// Websocket Endpoint for long living connections
     #[serde(skip_serializing)]
     pub ws_endpoint: RpcUrl,

--- a/crates/relayer-utils/src/lib.rs
+++ b/crates/relayer-utils/src/lib.rs
@@ -261,6 +261,10 @@ pub enum Error {
     /// are missing.
     #[error("Missing Substrate Static Transaction Validation Details")]
     MissingValidationDetails,
+    /// Rpc connection error.
+    /// This error is raised when the rpc connection fails.
+    #[error("Rpc connection Error: {}", _0)]
+    RpcConnectionError(String),
 }
 
 /// A type alias for the result for webb relayer, that uses the `Error` enum.

--- a/crates/tx-relay/src/evm/vanchor.rs
+++ b/crates/tx-relay/src/evm/vanchor.rs
@@ -69,11 +69,6 @@ pub async fn handle_vanchor_relay_tx<'a>(
         return Err(Withdraw(WithdrawStatus::InvalidMerkleRoots));
     }
 
-    tracing::debug!(
-        "Connecting to chain {:?} .. at {}",
-        cmd.chain_id,
-        chain.http_endpoint
-    );
     let _ = stream.send(Network(NetworkStatus::Connecting)).await;
     let provider = ctx.evm_provider(cmd.chain_id).await.map_err(|e| {
         Network(NetworkStatus::Failed {

--- a/examples/in_depth.rs
+++ b/examples/in_depth.rs
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
                 enabled: true,
                 http_endpoints: vec!["https://polygon-rpc.com/"]
                     .iter()
-                    .map(|x| x.parse::<url::Url>().unwrap())
+                    .map(|x| x.parse::<url::Url>().unwrap().into())
                     .collect(),
                 ws_endpoint: "wss://polygon-rpc.com/"
                     .parse::<url::Url>()?

--- a/examples/in_depth.rs
+++ b/examples/in_depth.rs
@@ -55,9 +55,10 @@ async fn main() -> anyhow::Result<()> {
             EvmChainConfig {
                 name: String::from("polygon"),
                 enabled: true,
-                http_endpoint: "https://polygon-rpc.com/"
-                    .parse::<url::Url>()?
-                    .into(),
+                http_endpoints: vec!["https://polygon-rpc.com/"]
+                    .iter()
+                    .map(|x| x.parse::<url::Url>().unwrap())
+                    .collect(),
                 ws_endpoint: "wss://polygon-rpc.com/"
                     .parse::<url::Url>()?
                     .into(),

--- a/services/webb-relayer/src/service/evm.rs
+++ b/services/webb-relayer/src/service/evm.rs
@@ -77,7 +77,7 @@ pub async fn ignite(
         }
         let chain_name = &chain_config.name;
         let chain_id = chain_config.chain_id;
-        let client = ctx.evm_provider(chain_id).await?;
+        let client = ctx.create_evm_provider(chain_id).await?;
         // Time lag offset tip.
         let block_confirmations = chain_config.block_confirmations;
         let timelag_client =

--- a/services/webb-relayer/src/service/evm.rs
+++ b/services/webb-relayer/src/service/evm.rs
@@ -103,6 +103,7 @@ pub async fn ignite(
                     start_signature_bridge_events_watcher(
                         ctx,
                         config,
+                        chain_id,
                         timelag_client.clone(),
                         store.clone(),
                     )
@@ -251,6 +252,7 @@ async fn start_vanchor_events_watcher(
                     VAnchorEncryptedOutputHandler::new(chain_id.into());
                 let vanchor_watcher_task = contract_watcher.run(
                     client,
+                    chain_id.into(),
                     store,
                     wrapper,
                     vec![
@@ -309,6 +311,7 @@ async fn start_vanchor_events_watcher(
                     VAnchorEncryptedOutputHandler::new(chain_id.into());
                 let vanchor_watcher_task = contract_watcher.run(
                     client,
+                    chain_id.into(),
                     store,
                     wrapper,
                     vec![
@@ -358,6 +361,7 @@ async fn start_vanchor_events_watcher(
                     VAnchorEncryptedOutputHandler::new(chain_id.into());
                 let vanchor_watcher_task = contract_watcher.run(
                     client,
+                    chain_id.into(),
                     store,
                     wrapper,
                     vec![
@@ -394,6 +398,7 @@ async fn start_vanchor_events_watcher(
 pub async fn start_signature_bridge_events_watcher(
     ctx: &RelayerContext,
     config: &SignatureBridgeContractConfig,
+    chain_id: u32,
     client: Arc<TimeLagClient>,
     store: Arc<super::Store>,
 ) -> crate::Result<()> {
@@ -422,6 +427,7 @@ pub async fn start_signature_bridge_events_watcher(
         let events_watcher_task = EventWatcher::run(
             &bridge_contract_watcher,
             client.clone(),
+            chain_id.into(),
             store.clone(),
             wrapper.clone(),
             vec![Box::new(governance_transfer_handler)],

--- a/tests/lib/localTestnet.ts
+++ b/tests/lib/localTestnet.ts
@@ -60,6 +60,7 @@ export type ExportedConfigOptions = {
   blockConfirmations?: number;
   privateKey?: string;
   smartAnchorUpdates?: SmartAnchorUpdatesConfig;
+  httpEndpoints?: string[];
 };
 
 // Default Events watcher for the contracts.
@@ -459,7 +460,7 @@ export class LocalChain {
     const chainInfo: FullChainInfo = {
       name: this.underlyingChainId.toString(),
       enabled: true,
-      httpEndpoint: this.endpoint,
+      httpEndpoints: opts.httpEndpoints ?? [this.endpoint],
       wsEndpoint: this.endpoint.replace('http', 'ws'),
       blockConfirmations: opts.blockConfirmations ?? 0,
       chainId: this.underlyingChainId,
@@ -476,7 +477,7 @@ export class LocalChain {
     const chainInfo: FullChainInfo = {
       name: this.underlyingChainId.toString(),
       enabled: true,
-      httpEndpoint: this.endpoint,
+      httpEndpoints: opts.httpEndpoints ?? [this.endpoint],
       wsEndpoint: this.endpoint.replace('http', 'ws'),
       blockConfirmations: opts.blockConfirmations ?? 1,
       chainId: this.underlyingChainId,
@@ -529,7 +530,7 @@ export class LocalChain {
     const convertedConfig: ConvertedConfig = {
       name: config.name,
       enabled: config.enabled,
-      'http-endpoint': config.httpEndpoint,
+      'http-endpoints': config.httpEndpoints,
       'ws-endpoint': config.wsEndpoint,
       'chain-id': config.chainId,
       'block-confirmations': config.blockConfirmations,
@@ -600,7 +601,7 @@ export class LocalChain {
 }
 
 export type FullChainInfo = ChainInfo & {
-  httpEndpoint: string;
+  httpEndpoints: string[];
   wsEndpoint: string;
   privateKey: string;
   blockConfirmations: number;

--- a/tests/test/evm/invalidProviders.test.ts
+++ b/tests/test/evm/invalidProviders.test.ts
@@ -78,7 +78,7 @@ describe('Invalid EVM Providers', () => {
             name: 'rate-limited-provider',
             enabled: true,
             'chain-id': 1,
-            'http-endpoint': provider.url,
+            'http-endpoints': [provider.url],
             'ws-endpoint': 'ws://localhost:8546',
             'block-confirmations': 0,
             contracts: [

--- a/tests/test/evm/vanchorTransactionRelayer.test.ts
+++ b/tests/test/evm/vanchorTransactionRelayer.test.ts
@@ -127,15 +127,18 @@ describe('Vanchor Transaction relayer', function () {
         [localChain2.chainId]: govWallet.address,
       }
     );
-
+    
     // save the chain configs.
+    const dummyEndpoint = 'http://127.0.0.1:1080'; // Relayer should fail and try connecting other endpoints.
     await localChain1.writeConfig(`${tmpDirPath}/${localChain1.name}.json`, {
       signatureVBridge,
       proposalSigningBackend: { type: 'Mocked', privateKey: PK1 },
+      httpEndpoints: [dummyEndpoint,localChain1.endpoint],
     });
     await localChain2.writeConfig(`${tmpDirPath}/${localChain2.name}.json`, {
       signatureVBridge,
       proposalSigningBackend: { type: 'Mocked', privateKey: PK2 },
+      httpEndpoints: [dummyEndpoint,localChain2.endpoint],
     });
 
     // get the vanhor on localchain1
@@ -183,6 +186,7 @@ describe('Vanchor Transaction relayer', function () {
       tmp: true,
       configDir: tmpDirPath,
       showLogs: true,
+      verbosity: 4,
     });
     await webbRelayer.waitUntilReady();
   });


### PR DESCRIPTION
## Summary of changes

### 1. Update EvmChainConfig to take multiple http-endpoints
```rust
pub struct EvmChainConfig {
    #[serde(skip_serializing)]
    pub http_endpoints: Vec<RpcUrl>,
}
```

### 2. Make evm_provider  mutable so we can update and cache latest working client

```rust
pub struct RelayerContext {
  .
  .
 /// Evm Providers Cache.
 evm_providers: Arc<Mutex<HashMap<types::U256, Arc<EthersClient>>>>,
}


pub async fn evm_provider<I: Into<types::U256>>(
        &self,
        chain_id: I,
    ) -> webb_relayer_utils::Result<Arc<EthersClient>> {
        let chain_id: types::U256 = chain_id.into();
        // Check if the provider is already in the cache or else create new provider from http_endpoint array.
        // If the provider is not working, try creating a new provider from http_endpoint array.

        if let Some(provider) = self.evm_providers.lock().await.get(&chain_id) {
            // get gas price to check if the provider is working
            let response = provider.get_gas_price().await;
            match response {
                Ok(_) => Ok(provider.clone()),
                Err(e) => {
                    tracing::error!(
                        "EVM Provider for chain {} is not working: {}.Try Connecting with other http_endpoints, if any.",
                        chain_id,
                        e
                    );
                    self.create_evm_provider(chain_id).await
                }
            }
        } else {
            self.create_evm_provider(chain_id).await
        }
    }


```


### 3. Update retry count for  RetryClient.

Since we want to switch between RPC providers, we should define a smaller limit for retires like ~50.  Once retry limit exceeds the current client is dropped and a new client is created by iterating over available rpc endpoints.
This will happen in the event_watcher::run() method

The `evm_provider` method will check the provider cache for the client and will do a sanity check for connection by making an API call. If the connection fails it will try to create a new evm_provider from the set of RPC endpoints in the loop.

```rust

let task = || async {
            let step = contract.max_blocks_per_step().as_u64();
            let provider = ctx.evm_provider(chain_id).await?;
            let client = Arc::new(TimeLag::new(
                provider,
                chain_config.block_confirmations,
            ));

     // drop client if retries exceed and create new clients after some back off time
}
```



### Reference issue to close (if applicable)
- Closes #499 

-----
### Code Checklist 

- [x] Tested
- [ ] Documented
