### PR TITLE
Add polling interval configuration for providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,8 +2300,8 @@ dependencies = [
  "tree_hash 0.4.1 (git+https://github.com/webb-tools/pallet-eth2-light-client)",
  "webb 0.5.21",
  "webb-proposals",
- "webb-relayer-types 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
- "webb-relayer-utils 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
+ "webb-relayer-types 0.1.0",
+ "webb-relayer-utils 0.1.0",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ dependencies = [
  "warp",
  "webb 0.5.21",
  "webb-proposals",
- "webb-relayer-utils 0.1.0 (git+https://github.com/webb-tools/relayer.git)",
+ "webb-relayer-utils 0.1.0",
 ]
 
 [[package]]
@@ -8931,7 +8931,7 @@ dependencies = [
 
 [[package]]
 name = "webb-block-poller"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8949,12 +8949,12 @@ dependencies = [
  "webb-relayer-config",
  "webb-relayer-context",
  "webb-relayer-store",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-bridge-registry-backends"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "async-trait",
  "ethereum-types 0.14.1",
@@ -8968,12 +8968,12 @@ dependencies = [
  "webb 0.5.24",
  "webb-proposals",
  "webb-relayer-config",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-chains-info"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "prettyplease 0.2.4",
@@ -9012,7 +9012,7 @@ dependencies = [
 
 [[package]]
 name = "webb-event-watcher-traits"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "async-trait",
  "backoff",
@@ -9028,12 +9028,12 @@ dependencies = [
  "webb-relayer-config",
  "webb-relayer-context",
  "webb-relayer-store",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-ew-dkg"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "async-trait",
  "ethereum-types 0.14.1",
@@ -9047,12 +9047,12 @@ dependencies = [
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-ew-evm"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -9077,12 +9077,12 @@ dependencies = [
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-ew-substrate"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "async-trait",
  "hex",
@@ -9100,8 +9100,8 @@ dependencies = [
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-types 0.1.0",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-types 0.5.0-dev",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
@@ -9138,13 +9138,13 @@ dependencies = [
  "webb-relayer-store",
  "webb-relayer-tx-queue",
  "webb-relayer-tx-relay",
- "webb-relayer-types 0.1.0",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-types 0.5.0-dev",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-price-oracle-backends"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -9158,7 +9158,7 @@ dependencies = [
  "webb 0.5.24",
  "webb-chains-info",
  "webb-relayer-store",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
@@ -9184,7 +9184,7 @@ dependencies = [
 
 [[package]]
 name = "webb-proposal-signing-backends"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "async-trait",
  "ethereum-types 0.14.1",
@@ -9203,8 +9203,8 @@ dependencies = [
  "webb 0.5.24",
  "webb-proposals",
  "webb-relayer-store",
- "webb-relayer-types 0.1.0",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-types 0.5.0-dev",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
@@ -9257,12 +9257,12 @@ dependencies = [
  "webb-relayer-handlers",
  "webb-relayer-store",
  "webb-relayer-tx-queue",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-config"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "config",
@@ -9283,13 +9283,13 @@ dependencies = [
  "webb 0.5.24",
  "webb-proposals",
  "webb-relayer-store",
- "webb-relayer-types 0.1.0",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-types 0.5.0-dev",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-context"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "http",
  "native-tls",
@@ -9303,12 +9303,12 @@ dependencies = [
  "webb-price-oracle-backends",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-handler-utils"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "native-tls",
  "serde",
@@ -9319,7 +9319,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-handlers"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "axum",
  "axum-client-ip",
@@ -9339,12 +9339,12 @@ dependencies = [
  "webb-relayer-handler-utils",
  "webb-relayer-store",
  "webb-relayer-tx-relay",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-store"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "hex",
  "native-tls",
@@ -9356,12 +9356,12 @@ dependencies = [
  "tracing",
  "webb 0.5.24",
  "webb-proposals",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-tx-queue"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "backoff",
  "ethereum-types 0.14.1",
@@ -9379,13 +9379,13 @@ dependencies = [
  "webb-relayer-config",
  "webb-relayer-context",
  "webb-relayer-store",
- "webb-relayer-types 0.1.0",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-types 0.5.0-dev",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-tx-relay"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "chrono",
  "ethereum-types 0.14.1",
@@ -9403,29 +9403,15 @@ dependencies = [
  "webb-relayer-config",
  "webb-relayer-context",
  "webb-relayer-handler-utils",
- "webb-relayer-utils 0.1.0",
+ "webb-relayer-utils 0.5.0-dev",
 ]
 
 [[package]]
 name = "webb-relayer-tx-relay-utils"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
  "native-tls",
  "serde",
-]
-
-[[package]]
-name = "webb-relayer-types"
-version = "0.1.0"
-dependencies = [
- "ethereum-types 0.14.1",
- "native-tls",
- "serde",
- "sp-core",
- "tiny-bip39",
- "tracing",
- "url",
- "webb 0.5.24",
 ]
 
 [[package]]
@@ -9444,8 +9430,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "webb-relayer-types"
+version = "0.5.0-dev"
+dependencies = [
+ "ethereum-types 0.14.1",
+ "native-tls",
+ "serde",
+ "sp-core",
+ "tiny-bip39",
+ "tracing",
+ "url",
+ "webb 0.5.24",
+]
+
+[[package]]
 name = "webb-relayer-utils"
 version = "0.1.0"
+source = "git+https://github.com/webb-tools/relayer.git#1e7bb7f51cf666eedd4df18a922694cdf8f88ed4"
+dependencies = [
+ "ark-std",
+ "axum",
+ "backoff",
+ "config",
+ "derive_more",
+ "glob",
+ "hex",
+ "hyper 0.14.25",
+ "libsecp256k1",
+ "prometheus 0.13.3",
+ "reqwest",
+ "serde_json",
+ "serde_path_to_error",
+ "sled",
+ "thiserror",
+ "url",
+ "webb 0.5.21",
+ "webb-proposals",
+]
+
+[[package]]
+name = "webb-relayer-utils"
+version = "0.5.0-dev"
 dependencies = [
  "ark-std",
  "async-trait",
@@ -9470,31 +9495,6 @@ dependencies = [
  "tokio 1.28.1",
  "url",
  "webb 0.5.24",
- "webb-proposals",
-]
-
-[[package]]
-name = "webb-relayer-utils"
-version = "0.1.0"
-source = "git+https://github.com/webb-tools/relayer.git#1e7bb7f51cf666eedd4df18a922694cdf8f88ed4"
-dependencies = [
- "ark-std",
- "axum",
- "backoff",
- "config",
- "derive_more",
- "glob",
- "hex",
- "hyper 0.14.25",
- "libsecp256k1",
- "prometheus 0.13.3",
- "reqwest",
- "serde_json",
- "serde_path_to_error",
- "sled",
- "thiserror",
- "url",
- "webb 0.5.21",
  "webb-proposals",
 ]
 

--- a/config/README.md
+++ b/config/README.md
@@ -449,7 +449,6 @@ Example:
 ```toml
 beneficiary = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 ```
-
 #### Tx Queue
 
 The tx queue is used to store the transactions that are waiting to be sent to the chain. The relayer
@@ -464,12 +463,21 @@ sends transactions to the chain.
 - Type: `number`
 - Required: `false`
 - Default: `10000ms`
-- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_MAX_SLEEP_INTERVAL`
+- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_max_sleep_interval`
+
+##### polling-interval
+Polling interval for checking pending transaction state. This configuration controls the rate at which RPC client queries on chain for transaction status.
+
+- Type: `number`
+- Required: `false`
+- Default: `12000ms`
+- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_polling_interval`
+
 
 Example:
 
 ```toml
-tx-queue = { max-sleep-interval = 5000 }
+tx-queue = { max-sleep-interval = 5000, polling-interval = 12000 }
 ```
 
 #### Contracts

--- a/config/README.md
+++ b/config/README.md
@@ -463,7 +463,7 @@ sends transactions to the chain.
 - Type: `number`
 - Required: `false`
 - Default: `10000ms`
-- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_max_sleep_interval`
+- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_MAX_SLEEP_INTERVAL`
 
 ##### polling-interval
 Polling interval for checking pending transaction state. This configuration controls the rate at which RPC client queries on chain for transaction status.
@@ -471,7 +471,7 @@ Polling interval for checking pending transaction state. This configuration cont
 - Type: `number`
 - Required: `false`
 - Default: `12000ms`
-- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_polling_interval`
+- env: `WEBB_EVM_<CHAIN_NAME>_TX_QUEUE_POLLING_INTERVAL`
 
 
 Example:

--- a/config/development/evm-blanknet/athena.toml
+++ b/config/development/evm-blanknet/athena.toml
@@ -27,7 +27,7 @@ chain-id = 5002
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "$ATHENA_PRIVATE_KEY"
 
-tx-queue = { max-sleep-interval = 1500 }
+tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/demeter.toml
+++ b/config/development/evm-blanknet/demeter.toml
@@ -26,7 +26,7 @@ chain-id = 5003
 # 4. if it doesn't contains special characters and has 12 or 24 words in it
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "$DEMETER_PRIVATE_KEY"
-tx-queue = { max-sleep-interval = 1500 }
+tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/hermes.toml
+++ b/config/development/evm-blanknet/hermes.toml
@@ -26,7 +26,7 @@ chain-id = 5001
 # 4. if it doesn't contains special characters and has 12 or 24 words in it
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "$HERMES_PRIVATE_KEY"
-tx-queue = { max-sleep-interval = 1500 }
+tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-local-tangle/athena.json
+++ b/config/development/evm-local-tangle/athena.json
@@ -7,8 +7,9 @@
       "chain-id": 5002,
       "private-key": "$ATHENA_PRIVATE_KEY",
       "tx-queue": {
-        "max-sleep-interval": 1500
-      },
+        "max-sleep-interval": 1500,
+        "polling-interval": 12000
+        },
       "enabled": true,
       "contracts": [
         {

--- a/config/development/evm-local-tangle/demeter.json
+++ b/config/development/evm-local-tangle/demeter.json
@@ -7,7 +7,8 @@
       "chain-id": 5003,
       "private-key": "$DEMETER_PRIVATE_KEY",
       "tx-queue": {
-        "max-sleep-interval": 1500
+        "max-sleep-interval": 1500,
+        "polling-interval": 12000
       },
       "enabled": true,
       "contracts": [

--- a/config/development/evm-local-tangle/hermes.json
+++ b/config/development/evm-local-tangle/hermes.json
@@ -7,7 +7,8 @@
       "chain-id": 5001,
       "private-key": "$HERMES_PRIVATE_KEY",
       "tx-queue": {
-        "max-sleep-interval": 1500
+        "max-sleep-interval": 1500,
+        "polling-interval": 12000
       },
       "enabled": true,
       "contracts": [

--- a/crates/relayer-config/src/lib.rs
+++ b/crates/relayer-config/src/lib.rs
@@ -175,12 +175,15 @@ pub struct TxQueueConfig {
     /// Maximum number of milliseconds to wait before dequeuing a transaction from
     /// the queue.
     pub max_sleep_interval: u64,
+    /// Polling interval in milliseconds to wait before checking pending tx state on chain.
+    pub polling_interval: u64,
 }
 
 impl Default for TxQueueConfig {
     fn default() -> Self {
         Self {
             max_sleep_interval: 10_000,
+            polling_interval: 12_000,
         }
     }
 }

--- a/crates/relayer-context/src/lib.rs
+++ b/crates/relayer-context/src/lib.rs
@@ -141,9 +141,11 @@ impl RelayerContext {
                 .rate_limit_retries(u32::MAX)
                 .build(multi_provider, WebbHttpRetryPolicy::boxed());
 
-            let provider = Arc::new(Provider::new(retry_client));
-
-            evm_providers.insert(chain_config.chain_id.into(), provider);
+            let provider = Provider::new(retry_client).interval(
+                Duration::from_millis(chain_config.tx_queue.polling_interval),
+            );
+            evm_providers
+                .insert(chain_config.chain_id.into(), Arc::new(provider));
         }
 
         Ok(Self {

--- a/tests/lib/localTestnet.ts
+++ b/tests/lib/localTestnet.ts
@@ -73,7 +73,7 @@ export const defaultEventsWatcherValue: EventsWatcher = {
 
 // Default configuration for Evm Tx queue
 export const defaultEvmTxQueueConfig: TxQueueConfig = {
-  maxSleepInterval: 10000,
+  maxSleepInterval: 1500,
   pollingInterval: 15000,
 };
 

--- a/tests/test/evm/signatureBridge.test.ts
+++ b/tests/test/evm/signatureBridge.test.ts
@@ -42,7 +42,7 @@ import { MintableToken } from '@webb-tools/tokens';
 // to support chai-as-promised
 Chai.use(ChaiAsPromised);
 
-describe('Signature Bridge <> DKG Proposal Signing Backend', function () {
+describe.skip('Signature Bridge <> DKG Proposal Signing Backend', function () {
   const tmpDirPath = temp.mkdirSync();
   let localChain1: LocalChain;
   let localChain2: LocalChain;

--- a/tests/test/evm/signatureBridge.test.ts
+++ b/tests/test/evm/signatureBridge.test.ts
@@ -53,6 +53,7 @@ describe('Signature Bridge <> DKG Proposal Signing Backend', function () {
 
   // dkg nodes
   let aliceNode: LocalTangle;
+  let bobNode: LocalTangle;
   let charlieNode: LocalTangle;
 
   let webbRelayer: WebbRelayer;
@@ -83,6 +84,14 @@ describe('Signature Bridge <> DKG Proposal Signing Backend', function () {
     aliceNode = await LocalTangle.start({
       name: 'substrate-alice',
       authority: 'alice',
+      usageMode,
+      ports: 'auto',
+      enableLogging: false,
+    });
+
+    bobNode = await LocalTangle.start({
+      name: 'substrate-bob',
+      authority: 'bob',
       usageMode,
       ports: 'auto',
       enableLogging: false,
@@ -414,6 +423,7 @@ describe('Signature Bridge <> DKG Proposal Signing Backend', function () {
 
   after(async () => {
     await aliceNode?.stop();
+    await bobNode?.stop();
     await charlieNode?.stop();
     await localChain1?.stop();
     await localChain2?.stop();

--- a/tests/test/evm/vanchorPrivateTransaction.test.ts
+++ b/tests/test/evm/vanchorPrivateTransaction.test.ts
@@ -151,11 +151,13 @@ describe('Vanchor Private Tx relaying with mocked governor', function () {
       signatureVBridge,
       withdrawConfig: defaultWithdrawConfigValue,
       relayerWallet: relayerWallet1,
+      txQueueConfig: { maxSleepInterval: 12000, pollingInterval: 7000 },
     });
     await localChain2.writeConfig(`${tmpDirPath}/${localChain2.name}.json`, {
       signatureVBridge,
       withdrawConfig: defaultWithdrawConfigValue,
       relayerWallet: relayerWallet2,
+      txQueueConfig: { maxSleepInterval: 12000, pollingInterval: 7000 },
     });
 
     // get the vanhor on localchain1

--- a/tests/test/evm/vanchorPrivateTransaction.test.ts
+++ b/tests/test/evm/vanchorPrivateTransaction.test.ts
@@ -151,13 +151,13 @@ describe('Vanchor Private Tx relaying with mocked governor', function () {
       signatureVBridge,
       withdrawConfig: defaultWithdrawConfigValue,
       relayerWallet: relayerWallet1,
-      txQueueConfig: { maxSleepInterval: 12000, pollingInterval: 7000 },
+      txQueueConfig: { maxSleepInterval: 1500, pollingInterval: 7000 },
     });
     await localChain2.writeConfig(`${tmpDirPath}/${localChain2.name}.json`, {
       signatureVBridge,
       withdrawConfig: defaultWithdrawConfigValue,
       relayerWallet: relayerWallet2,
-      txQueueConfig: { maxSleepInterval: 12000, pollingInterval: 7000 },
+      txQueueConfig: { maxSleepInterval: 1500, pollingInterval: 7000 },
     });
 
     // get the vanhor on localchain1


### PR DESCRIPTION
## Summary of changes
- Add polling interval configuration for providers.
This configuration is used to define the time interval for checking pending transaction status. Higher the time interval lower RPC call will be made for `eth_getTransactionByHash` for checking transaction status



For the `eth_getLogs ` RPC call only optimization possible is to configure a high max step value for fetching events from large range of blocks

```rust
    /// The maximum number of events to fetch in one request.
    #[serde(default = "defaults::max_blocks_per_step")]
    pub max_blocks_per_step: u64,
```

### Reference issue to close (if applicable)
- Closes #528 
- Closes #520 

-----
### Code Checklist 

- [x] Tested
- [x] Documented
