### PR TITLE
Add relayer fee configuration to relayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9500,7 +9500,7 @@ dependencies = [
 
 [[package]]
 name = "webb-bridge-registry-backends"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "async-trait",
  "ethereum-types 0.14.1",
@@ -9514,12 +9514,12 @@ dependencies = [
  "webb 0.7.3",
  "webb-proposals",
  "webb-relayer-config",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-chains-info"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -9558,7 +9558,7 @@ dependencies = [
 
 [[package]]
 name = "webb-event-watcher-traits"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "async-trait",
  "backoff",
@@ -9574,12 +9574,12 @@ dependencies = [
  "webb-relayer-config",
  "webb-relayer-context",
  "webb-relayer-store",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-ew-dkg"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "async-trait",
  "ethereum-types 0.14.1",
@@ -9593,12 +9593,12 @@ dependencies = [
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-ew-evm"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -9623,12 +9623,12 @@ dependencies = [
  "webb-proposals",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-price-oracle-backends"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -9642,7 +9642,7 @@ dependencies = [
  "webb 0.7.3",
  "webb-chains-info",
  "webb-relayer-store",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
@@ -9668,7 +9668,7 @@ dependencies = [
 
 [[package]]
 name = "webb-proposal-signing-backends"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "async-trait",
  "ethereum-types 0.14.1",
@@ -9687,8 +9687,8 @@ dependencies = [
  "webb 0.7.3",
  "webb-proposals",
  "webb-relayer-store",
- "webb-relayer-types 0.5.9-dev",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-types 0.5.10-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
@@ -9709,7 +9709,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -9739,12 +9739,12 @@ dependencies = [
  "webb-relayer-handlers",
  "webb-relayer-store",
  "webb-relayer-tx-queue",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-config"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "anyhow",
  "config",
@@ -9765,13 +9765,13 @@ dependencies = [
  "webb 0.7.3",
  "webb-proposals",
  "webb-relayer-store",
- "webb-relayer-types 0.5.9-dev",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-types 0.5.10-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-context"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "http",
  "native-tls",
@@ -9785,12 +9785,12 @@ dependencies = [
  "webb-price-oracle-backends",
  "webb-relayer-config",
  "webb-relayer-store",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-handler-utils"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "native-tls",
  "serde",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-handlers"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "axum",
  "axum-client-ip",
@@ -9823,12 +9823,12 @@ dependencies = [
  "webb-relayer-handler-utils",
  "webb-relayer-store",
  "webb-relayer-tx-relay",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-store"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "hex",
  "native-tls",
@@ -9840,12 +9840,12 @@ dependencies = [
  "tracing",
  "webb 0.7.3",
  "webb-proposals",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-tx-queue"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "backoff",
  "ethereum-types 0.14.1",
@@ -9864,13 +9864,13 @@ dependencies = [
  "webb-relayer-config",
  "webb-relayer-context",
  "webb-relayer-store",
- "webb-relayer-types 0.5.9-dev",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-types 0.5.10-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-tx-relay"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "chrono",
  "ethereum-types 0.14.1",
@@ -9889,12 +9889,12 @@ dependencies = [
  "webb-relayer-context",
  "webb-relayer-handler-utils",
  "webb-relayer-store",
- "webb-relayer-utils 0.5.9-dev",
+ "webb-relayer-utils 0.5.10-dev",
 ]
 
 [[package]]
 name = "webb-relayer-tx-relay-utils"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "native-tls",
  "serde",
@@ -9917,7 +9917,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-types"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "ethereum-types 0.14.1",
  "native-tls",
@@ -9960,7 +9960,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-utils"
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 dependencies = [
  "ark-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.5.9-dev"
+version = "0.5.10-dev"
 authors = ["Webb Developers <drew@webb.tools>"]
 license = "Apache-2.0"
 documentation = "https://docs.rs/webb-relayer"

--- a/config/README.md
+++ b/config/README.md
@@ -33,6 +33,9 @@ following section we will describe the different configuration entries and how t
   - [beneficiary](#beneficiary)
   - [tx-queue](#tx-queue)
     - [max-sleep-interval](#max-sleep-interval)
+  - [relayer-fee-config](#relayer-fee-config)
+    - [relayer-profit-percent](#relayer-profit-percent)
+    - [max-refund-amount](#max-refund-amount)
   - [contracts](#contracts)
     - [contract](#contract)
     - [address](#address)
@@ -467,6 +470,29 @@ Example:
 
 ```toml
 tx-queue = { max-sleep-interval = 5000, polling-interval = 12000 }
+```
+
+#### Relayer fee Config
+This configuration is used to configure profit percentage margin for relayer and set maximum amount relayer can refund to user while withdrawing.
+
+##### relayer-profit-percent
+The percentage of profit relayer will get from the transaction fee.
+
+- Type: `number`
+- Required: `false`
+- Default: `5`
+
+##### max-refund-amount
+The maximum amount of native token that relayer will refund to the user.
+
+- Type: `number`
+- Required: `false`
+- Default: `5`
+
+Example:
+
+```toml
+relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
 ```
 
 #### Contracts

--- a/config/README.md
+++ b/config/README.md
@@ -492,7 +492,7 @@ The maximum amount of native token that relayer will refund to the user.
 Example:
 
 ```toml
-relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
+relayer-fee-config = { relayer-profit-percent= 5, max-refund-amount = 5 }
 ```
 
 #### Contracts

--- a/config/README.md
+++ b/config/README.md
@@ -483,7 +483,7 @@ The percentage of profit relayer will get from the transaction fee.
 - Default: `5`
 
 ##### max-refund-amount
-The maximum amount of native token that relayer will refund to the user.
+The maximum amount of native token that relayer will refund to the user in USD.
 
 - Type: `number`
 - Required: `false`

--- a/config/development/evm-blanknet/athena.toml
+++ b/config/development/evm-blanknet/athena.toml
@@ -29,9 +29,9 @@ private-key = "$ATHENA_PRIVATE_KEY"
 
 tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
 # The relayer fee configuration for this chain.
-# relayer-profit-precent is percentage of profit relayer will get from the transaction fee.
+# relayer-profit-percentis percentage of profit relayer will get from the transaction fee.
 # max-refund-amount is the maximum amount of native token that relayer will refund to the user( in usd)
-relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
+relayer-fee-config = { relayer-profit-percent= 5, max-refund-amount = 5 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/athena.toml
+++ b/config/development/evm-blanknet/athena.toml
@@ -28,6 +28,10 @@ chain-id = 5002
 private-key = "$ATHENA_PRIVATE_KEY"
 
 tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
+# The relayer fee configuration for this chain.
+# relayer-profit-precent is percentage of profit relayer will get from the transaction fee.
+# max-refund-amount is the maximum amount of native token that relayer will refund to the user( in usd)
+relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/demeter.toml
+++ b/config/development/evm-blanknet/demeter.toml
@@ -27,6 +27,10 @@ chain-id = 5003
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "$DEMETER_PRIVATE_KEY"
 tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
+# The relayer fee configuration for this chain.
+# relayer-profit-precent is percentage of profit relayer will get from the transaction fee.
+# max-refund-amount is the maximum amount of native token that relayer will refund to the user( in usd)
+relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/demeter.toml
+++ b/config/development/evm-blanknet/demeter.toml
@@ -28,9 +28,9 @@ chain-id = 5003
 private-key = "$DEMETER_PRIVATE_KEY"
 tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
 # The relayer fee configuration for this chain.
-# relayer-profit-precent is percentage of profit relayer will get from the transaction fee.
+# relayer-profit-percentis percentage of profit relayer will get from the transaction fee.
 # max-refund-amount is the maximum amount of native token that relayer will refund to the user( in usd)
-relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
+relayer-fee-config = { relayer-profit-percent = 5, max-refund-amount = 5 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/hermes.toml
+++ b/config/development/evm-blanknet/hermes.toml
@@ -28,9 +28,9 @@ chain-id = 5001
 private-key = "$HERMES_PRIVATE_KEY"
 tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
 # The relayer fee configuration for this chain.
-# relayer-profit-precent is percentage of profit relayer will get from the transaction fee.
+# relayer-profit-percentis percentage of profit relayer will get from the transaction fee.
 # max-refund-amount is the maximum amount of native token that relayer will refund to the user( in usd)
-relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
+relayer-fee-config = { relayer-profit-percent= 5, max-refund-amount = 5 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-blanknet/hermes.toml
+++ b/config/development/evm-blanknet/hermes.toml
@@ -27,6 +27,10 @@ chain-id = 5001
 #    then we should process it as a mnemonic string: 'word two three four ...'
 private-key = "$HERMES_PRIVATE_KEY"
 tx-queue = { max-sleep-interval = 1500, polling-interval = 12000 }
+# The relayer fee configuration for this chain.
+# relayer-profit-precent is percentage of profit relayer will get from the transaction fee.
+# max-refund-amount is the maximum amount of native token that relayer will refund to the user( in usd)
+relayer-fee-config = { relayer-profit-precent = 5, max-refund-amount = 5 }
 # Value to indicate that the relayer should enable services for this chain
 enabled = true
 

--- a/config/development/evm-local-tangle/athena.json
+++ b/config/development/evm-local-tangle/athena.json
@@ -10,6 +10,10 @@
         "max-sleep-interval": 1500,
         "polling-interval": 12000
         },
+      "relayer-fee-config" : {
+        "relayer-profit-percent": 5,
+        "max-refund-amount": 5
+      },
       "enabled": true,
       "contracts": [
         {

--- a/config/development/evm-local-tangle/demeter.json
+++ b/config/development/evm-local-tangle/demeter.json
@@ -10,6 +10,10 @@
         "max-sleep-interval": 1500,
         "polling-interval": 12000
       },
+      "relayer-fee-config" : {
+        "relayer-profit-percent": 5,
+        "max-refund-amount": 5
+      },
       "enabled": true,
       "contracts": [
         {

--- a/config/development/evm-local-tangle/hermes.json
+++ b/config/development/evm-local-tangle/hermes.json
@@ -10,6 +10,10 @@
         "max-sleep-interval": 1500,
         "polling-interval": 12000
       },
+      "relayer-fee-config" : {
+        "relayer-profit-percent": 5,
+        "max-refund-amount": 5
+      },
       "enabled": true,
       "contracts": [
         {

--- a/crates/relayer-config/src/evm/mod.rs
+++ b/crates/relayer-config/src/evm/mod.rs
@@ -71,9 +71,31 @@ pub struct EvmChainConfig {
     /// TxQueue configuration
     #[serde(skip_serializing, default)]
     pub tx_queue: TxQueueConfig,
+    /// TxWithdrawFee configuration
+    #[serde(skip_serializing, default)]
+    pub withdraw_fee_config: WithdrawFeeConfig,
     /// Block poller/listening configuration
     #[serde(skip_serializing, default)]
     pub block_poller: Option<BlockPollerConfig>,
+}
+
+/// Transaction withdraw fee configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "kebab-case"))]
+pub struct WithdrawFeeConfig {
+    /// Relayer profit percent per transaction fee for relaying
+    pub relayer_profit_percent: f64,
+    /// Maximum refund amount per transaction relaying
+    pub max_refund_amount: f64,
+}
+
+impl Default for WithdrawFeeConfig {
+    fn default() -> Self {
+        Self {
+            relayer_profit_percent: 5.,
+            max_refund_amount: 5.,
+        }
+    }
 }
 
 /// configuration for adding http endpoints.

--- a/crates/relayer-config/src/evm/mod.rs
+++ b/crates/relayer-config/src/evm/mod.rs
@@ -72,7 +72,7 @@ pub struct EvmChainConfig {
     #[serde(skip_serializing, default)]
     pub tx_queue: TxQueueConfig,
     /// Relayer fee configuration
-    #[serde(skip_serializing, default)]
+    #[serde(default)]
     pub relayer_fee_config: RelayerFeeConfig,
     /// Block poller/listening configuration
     #[serde(skip_serializing, default)]

--- a/crates/relayer-config/src/evm/mod.rs
+++ b/crates/relayer-config/src/evm/mod.rs
@@ -71,9 +71,9 @@ pub struct EvmChainConfig {
     /// TxQueue configuration
     #[serde(skip_serializing, default)]
     pub tx_queue: TxQueueConfig,
-    /// TxWithdrawFee configuration
+    /// Relayer fee configuration
     #[serde(skip_serializing, default)]
-    pub withdraw_fee_config: WithdrawFeeConfig,
+    pub relayer_fee_config: RelayerFeeConfig,
     /// Block poller/listening configuration
     #[serde(skip_serializing, default)]
     pub block_poller: Option<BlockPollerConfig>,
@@ -82,14 +82,14 @@ pub struct EvmChainConfig {
 /// Transaction withdraw fee configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "kebab-case"))]
-pub struct WithdrawFeeConfig {
+pub struct RelayerFeeConfig {
     /// Relayer profit percent per transaction fee for relaying
     pub relayer_profit_percent: f64,
     /// Maximum refund amount per transaction relaying
     pub max_refund_amount: f64,
 }
 
-impl Default for WithdrawFeeConfig {
+impl Default for RelayerFeeConfig {
     fn default() -> Self {
         Self {
             relayer_profit_percent: 5.,

--- a/crates/tx-relay/src/evm/fees.rs
+++ b/crates/tx-relay/src/evm/fees.rs
@@ -260,9 +260,9 @@ fn calculate_transaction_fee(
     let tx_fee_usd = tx_fee_tokens * native_token_price;
     // Step 3: Calculate the profit that the relayer should make, and add it to the tx fee in USD.
     // This is the total amount of USD that the relayer should receive.
-    let relay_tx_fee =
+    let relay_tx_profit =
         (relayer_fee_config.relayer_profit_percent / 100.0) * tx_fee_usd;
-    let total_fee_with_profit_in_usd = tx_fee_usd + relay_tx_fee;
+    let total_fee_with_profit_in_usd = tx_fee_usd + relay_tx_profit;
     // Step 4: Convert the total fee to `wrappedToken` using the exchange rate for the underlying
     // wrapped token.
     // This is the total amount of `wrappedToken` that the relayer should receive.

--- a/crates/tx-relay/src/lib.rs
+++ b/crates/tx-relay/src/lib.rs
@@ -2,10 +2,5 @@
 #[cfg(feature = "evm")]
 pub mod evm;
 
-/// Maximum refund amount per relay transaction in USD.
-const MAX_REFUND_USD: f64 = 5.;
-/// Amount of profit that the relay should make with each transaction (in USD).
-const TRANSACTION_PROFIT_USD: f64 = 5.;
-
 /// Type alias for transaction item key.
 pub type TransactionItemKey = ethereum_types::H512;

--- a/examples/in_depth.rs
+++ b/examples/in_depth.rs
@@ -108,7 +108,7 @@ async fn main() -> anyhow::Result<()> {
                 block_poller: None,
                 block_confirmations: 0,
                 tx_queue: Default::default(),
-                relayer_fee_config: Default::default()
+                relayer_fee_config: Default::default(),
             },
         )]),
         ..Default::default()

--- a/examples/in_depth.rs
+++ b/examples/in_depth.rs
@@ -108,6 +108,7 @@ async fn main() -> anyhow::Result<()> {
                 block_poller: None,
                 block_confirmations: 0,
                 tx_queue: Default::default(),
+                relayer_fee_config: Default::default()
             },
         )]),
         ..Default::default()

--- a/tests/lib/localTestnet.ts
+++ b/tests/lib/localTestnet.ts
@@ -42,7 +42,7 @@ import {
   ProposalSigningBackend,
   SmartAnchorUpdatesConfig,
   RelayerFeeConfig,
-} from './webbRelayer';
+} from './webbRelayer.js';
 import { ConvertToKebabCase } from './tsHacks';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { TokenConfig, VBridge, VBridgeInput } from '@webb-tools/vbridge';
@@ -563,7 +563,7 @@ export class LocalChain {
         'polling-interval': config.txQueue.pollingInterval,
       },
       'relayer-fee-config': {
-        'relayer-fee-percent': config.relayerFeeConfig.relayerFeePercent,
+        'relayer-profit-percent': config.relayerFeeConfig.relayerProfitPercent,
         'max-refund-amount': config.relayerFeeConfig.maxRefundAmount,
       },
       contracts: config.contracts.map(
@@ -618,7 +618,9 @@ export class LocalChain {
         [this.underlyingChainId]: convertedConfig,
       },
     };
+
     const configString = JSON.stringify(fullConfigFile, null, 2);
+    console.log(configString);
     fs.writeFileSync(path, configString);
   }
 

--- a/tests/lib/localTestnet.ts
+++ b/tests/lib/localTestnet.ts
@@ -35,13 +35,13 @@ import {
 import {
   ChainInfo,
   Contract,
-  defaultWithdrawConfigValue,
+  defaultRelayerFeeConfigValue,
   EnabledContracts,
   EventsWatcher,
   LinkedAnchor,
   ProposalSigningBackend,
   SmartAnchorUpdatesConfig,
-  WithdrawFeeConfig,
+  RelayerFeeConfig,
 } from './webbRelayer';
 import { ConvertToKebabCase } from './tsHacks';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
@@ -56,7 +56,7 @@ export type GanacheAccounts = {
 export type ExportedConfigOptions = {
   signatureVBridge?: VBridge<VAnchor>;
   proposalSigningBackend?: ProposalSigningBackend;
-  withdrawConfig?: WithdrawFeeConfig;
+  relayerFeeConfig?: RelayerFeeConfig;
   relayerWallet?: Wallet;
   linkedAnchors?: LinkedAnchor[];
   blockConfirmations?: number;
@@ -483,7 +483,7 @@ export class LocalChain {
       privateKey: (wallet as ethers.Wallet).privateKey,
       contracts: contracts,
       txQueue: opts.txQueueConfig ?? defaultEvmTxQueueConfig,
-      withdrawFeeConfig: opts.withdrawConfig ?? defaultWithdrawConfigValue,
+      relayerFeeConfig: opts.relayerFeeConfig ?? defaultRelayerFeeConfigValue,
     };
     return chainInfo;
   }
@@ -502,7 +502,7 @@ export class LocalChain {
       privateKey: opts.privateKey ?? '',
       contracts: [],
       txQueue: defaultEvmTxQueueConfig,
-      withdrawFeeConfig: defaultWithdrawConfigValue,
+      relayerFeeConfig: defaultRelayerFeeConfigValue,
     };
     for (const contract of this.opts.enabledContracts) {
       if (contract.contract == 'VAnchor') {
@@ -533,14 +533,14 @@ export class LocalChain {
       'smart-anchor-updates'?: ConvertToKebabCase<SmartAnchorUpdatesConfig>;
     };
     type ConvertedTxQueueConfig = ConvertToKebabCase<TxQueueConfig>;
-    type ConvertedWithdrawFeeConfig = ConvertToKebabCase<WithdrawFeeConfig>;
+    type ConvertedRelayerFeeConfig = ConvertToKebabCase<RelayerFeeConfig>;
     type ConvertedConfig = Omit<
       ConvertToKebabCase<typeof config>,
-      'contracts' | 'tx-queue' | 'withdraw-fee-config'
+      'contracts' | 'tx-queue' | 'relayer-fee-config'
     > & {
       contracts: ConvertedContract[];
       'tx-queue': ConvertedTxQueueConfig;
-      'withdraw-fee-config'?: ConvertedWithdrawFeeConfig;
+      'relayer-fee-config'?: ConvertedRelayerFeeConfig;
     };
     type FullConfigFile = {
       evm: {
@@ -562,9 +562,9 @@ export class LocalChain {
         'max-sleep-interval': config.txQueue.maxSleepInterval,
         'polling-interval': config.txQueue.pollingInterval,
       },
-      'withdraw-fee-config': {
-        'relayer-fee-percent': config.withdrawFeeConfig.relayerFeePercent,
-        'max-refund-amount': config.withdrawFeeConfig.maxRefundAmount,
+      'relayer-fee-config': {
+        'relayer-fee-percent': config.relayerFeeConfig.relayerFeePercent,
+        'max-refund-amount': config.relayerFeeConfig.maxRefundAmount,
       },
       contracts: config.contracts.map(
         (contract): ConvertedContract => ({
@@ -686,7 +686,7 @@ export type FullChainInfo = ChainInfo & {
   privateKey: string;
   blockConfirmations: number;
   txQueue: TxQueueConfig;
-  withdrawFeeConfig: WithdrawFeeConfig;
+  relayerFeeConfig: RelayerFeeConfig;
 };
 
 export async function setupVanchorEvmTx(

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -402,7 +402,7 @@ export interface EvmEtherscanConfig {
   [key: string]: EtherscanApiConfig;
 }
 
-export interface WithdrawFeeConfig {
+export interface RelayerFeeConfig {
   relayerFeePercent: number;
   maxRefundAmount: number;
 }
@@ -552,7 +552,7 @@ export interface EnabledContracts {
 }
 
 // Default WithdrawlFeeConfig for the tx relaying.
-export const defaultWithdrawConfigValue: WithdrawFeeConfig = {
+export const defaultRelayerFeeConfigValue: RelayerFeeConfig = {
   maxRefundAmount: 0,
   relayerFeePercent: 0,
 };

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -403,7 +403,7 @@ export interface EvmEtherscanConfig {
 }
 
 export interface RelayerFeeConfig {
-  relayerFeePercent: number;
+  relayerProfitPercent: number;
   maxRefundAmount: number;
 }
 
@@ -554,7 +554,7 @@ export interface EnabledContracts {
 // Default WithdrawlFeeConfig for the tx relaying.
 export const defaultRelayerFeeConfigValue: RelayerFeeConfig = {
   maxRefundAmount: 0,
-  relayerFeePercent: 0,
+  relayerProfitPercent: 0,
 };
 
 type ContractKind =

--- a/tests/lib/webbRelayer.ts
+++ b/tests/lib/webbRelayer.ts
@@ -402,9 +402,9 @@ export interface EvmEtherscanConfig {
   [key: string]: EtherscanApiConfig;
 }
 
-export interface WithdrawConfig {
-  withdrawFeePercentage: number;
-  withdrawGaslimit: `0x${string}`;
+export interface WithdrawFeeConfig {
+  relayerFeePercent: number;
+  maxRefundAmount: number;
 }
 
 export interface WebbRelayerInfo {
@@ -506,7 +506,6 @@ export interface Contract {
   deployedAt: number;
   eventsWatcher: EventsWatcher;
   size?: number;
-  withdrawConfig?: WithdrawConfig;
   proposalSigningBackend?: ProposalSigningBackend;
   linkedAnchors?: LinkedAnchor[];
   smartAnchorUpdates?: SmartAnchorUpdatesConfig;
@@ -552,10 +551,10 @@ export interface EnabledContracts {
   contract: ContractKind;
 }
 
-// Default WithdrawlConfig for the contracts.
-export const defaultWithdrawConfigValue: WithdrawConfig = {
-  withdrawGaslimit: '0x5B8D80',
-  withdrawFeePercentage: 0,
+// Default WithdrawlFeeConfig for the tx relaying.
+export const defaultWithdrawConfigValue: WithdrawFeeConfig = {
+  maxRefundAmount: 0,
+  relayerFeePercent: 0,
 };
 
 type ContractKind =

--- a/tests/sim/smartAnchorUpdates.sim.ts
+++ b/tests/sim/smartAnchorUpdates.sim.ts
@@ -46,7 +46,7 @@ import { BigNumber, ethers } from 'ethers';
 import temp from 'temp';
 import { LocalChain } from '../lib/localTestnet.js';
 import {
-  defaultWithdrawConfigValue,
+  defaultRelayerFeeConfigValue,
   EnabledContracts,
   LinkedAnchor,
   WebbRelayer,
@@ -184,7 +184,7 @@ describe('Smart Anchor Updates Simulation', function () {
       const path = `${tmpDirPath}/${chain.name}.json`;
       await chain.writeConfig(path, {
         signatureVBridge,
-        withdrawConfig: defaultWithdrawConfigValue,
+        relayerFeeConfig: defaultRelayerFeeConfigValue,
         relayerWallet: relayerWallet,
         linkedAnchors: myLinkedAnchors,
         smartAnchorUpdates: {

--- a/tests/test/evm/relayerTxTransfer.test.ts
+++ b/tests/test/evm/relayerTxTransfer.test.ts
@@ -23,7 +23,7 @@ import { BigNumber, ethers } from 'ethers';
 import temp from 'temp';
 import { LocalChain } from '../../lib/localTestnet.js';
 import {
-  defaultWithdrawConfigValue,
+  defaultRelayerFeeConfigValue,
   EnabledContracts,
   EvmFeeInfo,
   EvmEtherscanConfig,
@@ -110,7 +110,7 @@ describe('Relayer transfer assets', function () {
     // save the chain configs.
     await localChain1.writeConfig(`${tmpDirPath}/${localChain1.name}.json`, {
       signatureVBridge,
-      withdrawConfig: defaultWithdrawConfigValue,
+      relayerFeeConfig: defaultRelayerFeeConfigValue,
       relayerWallet: relayerWallet1,
     });
 

--- a/tests/test/evm/vanchorPrivateTransaction.test.ts
+++ b/tests/test/evm/vanchorPrivateTransaction.test.ts
@@ -23,7 +23,7 @@ import { BigNumber, ethers } from 'ethers';
 import temp from 'temp';
 import { LocalChain, setupVanchorEvmTx } from '../../lib/localTestnet.js';
 import {
-  defaultWithdrawConfigValue,
+  defaultRelayerFeeConfigValue,
   EnabledContracts,
   EvmFeeInfo,
   EvmEtherscanConfig,
@@ -152,13 +152,13 @@ describe('Vanchor Private Tx relaying with mocked governor', function () {
     // save the chain configs.
     await localChain1.writeConfig(`${tmpDirPath}/${localChain1.name}.json`, {
       signatureVBridge,
-      withdrawConfig: defaultWithdrawConfigValue,
+      relayerFeeConfig: defaultRelayerFeeConfigValue,
       relayerWallet: relayerWallet1,
       txQueueConfig: { maxSleepInterval: 1500, pollingInterval: 7000 },
     });
     await localChain2.writeConfig(`${tmpDirPath}/${localChain2.name}.json`, {
       signatureVBridge,
-      withdrawConfig: defaultWithdrawConfigValue,
+      relayerFeeConfig: defaultRelayerFeeConfigValue,
       relayerWallet: relayerWallet2,
       txQueueConfig: { maxSleepInterval: 1500, pollingInterval: 7000 },
     });


### PR DESCRIPTION
## Summary of changes
- [x] Add Relayer fee configuration
- [x] Update test
- [x] Update config files
- [x] Update readme

Added Relayer fee configuration, which can be used by each chain to configure `relayer_profit_percent` and  `max_refund_amount` of the relayer

```rust
/// Transaction relayer fee configuration.
#[derive(Debug, Clone, Deserialize, Serialize)]
#[serde(rename_all(serialize = "camelCase", deserialize = "kebab-case"))]
pub struct RelayerFeeConfig {
    /// Relayer profit percent per transaction fee for relaying
    pub relayer_profit_percent: f64,
    /// Maximum refund amount per transaction relaying
    pub max_refund_amount: f64,
}

impl Default for RelayerFeeConfig {
    fn default() -> Self {
        Self {
            relayer_profit_percent: 5.,
            max_refund_amount: 5.,
        }
    }
}
```



### Reference issue to close (if applicable)
- Closes #570 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
