### PR TITLE
Added get_item function to get specific transaction from queue

### DIFF
--- a/config/development/local-evm/config.json
+++ b/config/development/local-evm/config.json
@@ -1,0 +1,198 @@
+{
+    "features": {
+      "governance-relay": true,
+      "data-query": true,
+      "private-tx-relay": true
+    },
+    "assets": {
+      "tTNT": {
+        "name": "Test Tangle Token",
+        "decimals": 18,
+        "price": 10
+      },
+      "TNT": {
+        "name": "Tangle Token",
+        "decimals": 18,
+        "price": 10
+      }
+    },
+    "evm": {
+      "athena": {
+        "name": "athena",
+        "http-endpoint": "http://localhost:5002",
+        "ws-endpoint": "ws://localhost:5002",
+        "explorer": "https://athena-explorer.webb.tools",
+        "chain-id": 5002,
+        "block-confirmations": 0,
+        "private-key": "$ATHENA_PRIVATE_KEY",
+        "enabled": true,
+        "contracts": [
+          {
+            "contract": "VAnchor",
+            "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3",
+            "deployed-at": 1,
+            "events-watcher": {
+              "enabled": true,
+              "polling-interval": 1000,
+              "print-progress-interval": 60000
+            },
+            "withdraw-config": {
+              "withdraw-fee-percentage": 0,
+              "withdraw-gaslimit": "0x350000"
+            },
+            "linked-anchors": [
+              {
+                "type": "Evm",
+                "chain": "hermes",
+                "chain-id": 5001,
+                "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+              },
+              {
+                "type": "Evm",
+                "chain": "demeter",
+                "chain-id": 5003,
+                "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+              }
+            ],
+            "smart-anchor-updates": {
+              "enabled": false,
+              "max-time-delay": 10,
+              "min-time-delay": 5
+            },
+            "proposal-signing-backend": {
+              "type": "Mocked",
+              "private-key": "$GOVERNOR_PRIVATE_KEY"
+            }
+          },
+          {
+            "contract": "SignatureBridge",
+            "address": "0x2946259E0334f33A064106302415aD3391BeD384",
+            "deployed-at": 1,
+            "events-watcher": {
+              "enabled": true,
+              "polling-interval": 1000,
+              "print-progress-interval": 60000
+            }
+          }
+        ]
+      },
+      "hermes": {
+        "name": "hermes",
+        "http-endpoint": "http://localhost:5001",
+        "ws-endpoint": "ws://localhost:5001",
+        "explorer": "https://hermes-explorer.webb.tools",
+        "chain-id": 5001,
+        "block-confirmations": 0,
+        "private-key": "$HERMES_PRIVATE_KEY",
+        "enabled": true,
+        "contracts": [
+          {
+            "contract": "VAnchor",
+            "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3",
+            "deployed-at": 1,
+            "events-watcher": {
+              "enabled": true,
+              "polling-interval": 1000,
+              "print-progress-interval": 60000
+            },
+            "withdraw-config": {
+              "withdraw-fee-percentage": 0,
+              "withdraw-gaslimit": "0x350000"
+            },
+            "linked-anchors": [
+              {
+                "type": "Evm",
+                "chain": "athena",
+                "chain-id": 5002,
+                "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+              },
+              {
+                "type": "Evm",
+                "chain": "demeter",
+                "chain-id": 5003,
+                "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+              }
+            ],
+            "smart-anchor-updates": {
+              "enabled": false,
+              "max-time-delay": 10,
+              "min-time-delay": 5
+            },
+            "proposal-signing-backend": {
+              "type": "Mocked",
+              "private-key": "$GOVERNOR_PRIVATE_KEY"
+            }
+          },
+          {
+            "contract": "SignatureBridge",
+            "address": "0x2946259E0334f33A064106302415aD3391BeD384",
+            "deployed-at": 1,
+            "events-watcher": {
+              "enabled": true,
+              "polling-interval": 1000,
+              "print-progress-interval": 60000
+            }
+          }
+        ]
+      },
+      "demeter": {
+        "name": "demeter",
+        "http-endpoint": "http://localhost:5003",
+        "ws-endpoint": "ws://localhost:5003",
+        "explorer": "https://demeter-explorer.webb.tools",
+        "chain-id": 5003,
+        "block-confirmations": 0,
+        "private-key": "$DEMETER_PRIVATE_KEY",
+        "enabled": true,
+        "contracts": [
+          {
+            "contract": "VAnchor",
+            "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3",
+            "deployed-at": 1,
+            "events-watcher": {
+              "enabled": true,
+              "polling-interval": 1000,
+              "print-progress-interval": 60000
+            },
+            "withdraw-config": {
+              "withdraw-fee-percentage": 0,
+              "withdraw-gaslimit": "0x350000"
+            },
+            "linked-anchors": [
+              {
+                "type": "Evm",
+                "chain": "athena",
+                "chain-id": 5002,
+                "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+              },
+              {
+                "type": "Evm",
+                "chain": "hermes",
+                "chain-id": 5001,
+                "address": "0x91eB86019FD8D7c5a9E31143D422850A13F670A3"
+              }
+            ],
+            "smart-anchor-updates": {
+              "enabled": false,
+              "max-time-delay": 10,
+              "min-time-delay": 5
+            },
+            "proposal-signing-backend": {
+              "type": "Mocked",
+              "private-key": "$GOVERNOR_PRIVATE_KEY"
+            }
+          },
+          {
+            "contract": "SignatureBridge",
+            "address": "0x2946259E0334f33A064106302415aD3391BeD384",
+            "deployed-at": 1,
+            "events-watcher": {
+              "enabled": true,
+              "polling-interval": 1000,
+              "print-progress-interval": 60000
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/crates/chains-info/fixtures/chains.json
+++ b/crates/chains-info/fixtures/chains.json
@@ -14085,6 +14085,45 @@
     ]
   },
   {
+    "name": "Athena Local",
+    "chain": "athena",
+    "rpc": ["http://localhost:5002"],
+    "faucets": [],
+    "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
+    "infoURL": "https://webb.tools",
+    "shortName": "athena",
+    "chainId": 5002,
+    "networkId": 5002,
+    "status": "testnet",
+    "explorers": []
+  },
+  {
+    "name": "Hermes Local",
+    "chain": "hermes",
+    "rpc": ["http://localhost:5001"],
+    "faucets": [],
+    "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
+    "infoURL": "https://webb.tools",
+    "shortName": "hermes",
+    "chainId": 5001,
+    "networkId": 5001,
+    "status": "testnet",
+    "explorers": []
+  },
+  {
+    "name": "Demeter Local",
+    "chain": "demeter",
+    "rpc": ["http://localhost:5003"],
+    "faucets": [],
+    "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
+    "infoURL": "https://webb.tools",
+    "shortName": "demeter",
+    "chainId": 5003,
+    "networkId": 5003,
+    "status": "testnet",
+    "explorers": []
+  },
+  {
     "name": "Tangle testnet",
     "chain": "tangle",
     "rpc": [

--- a/crates/chains-info/supported_chains.toml
+++ b/crates/chains-info/supported_chains.toml
@@ -15,6 +15,9 @@ chain-ids = [
     3884533461, # Athena Testnet
     3884533462, # Hermes Testnet
     3884533463, # Demeter Testnet
+    5001,# Athena Local Testnet
+    5002,# Athena Local Testnet
+    5003,# Athena Local Testnet
     4006, # Tangle EVM Testnet
 ]
 

--- a/crates/relayer-handlers/src/routes/transaction_status.rs
+++ b/crates/relayer-handlers/src/routes/transaction_status.rs
@@ -34,7 +34,7 @@ pub async fn handle_transaction_status_evm(
 ) -> Result<Json<TransactionStatusResponse>, HandlerError> {
     let store = ctx.store();
     let maybe_item: Option<QueueItem<TypedTransaction>> = store
-        .peek_item(SledQueueKey::from_evm_with_custom_key(chain_id, item_key.0))
+        .get_item(SledQueueKey::from_evm_with_custom_key(chain_id, item_key.0))
         .unwrap_or(None);
 
     if let Some(item) = maybe_item {

--- a/crates/relayer-store/src/queue.rs
+++ b/crates/relayer-store/src/queue.rs
@@ -129,6 +129,11 @@ where
     ) -> crate::Result<Option<QueueItem<Item>>>;
     /// Check if the item is in the queue.
     fn has_item(&self, key: Self::Key) -> crate::Result<bool>;
+    /// Get item from the queue.
+    fn get_item(
+        &self,
+        key: Self::Key,
+    ) -> crate::Result<Option<QueueItem<Item>>>;
     /// Remove an item from the queue.
     fn remove_item(
         &self,
@@ -179,6 +184,10 @@ where
 
     fn has_item(&self, key: Self::Key) -> crate::Result<bool> {
         S::has_item(self, key)
+    }
+
+    fn get_item(&self, key: Self::Key) -> crate::Result<Option<QueueItem<T>>> {
+        S::get_item(self, key)
     }
 
     fn remove_item(

--- a/crates/tx-queue/src/evm/evm_tx_queue.rs
+++ b/crates/tx-queue/src/evm/evm_tx_queue.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ethereum_types::{H256, U64};
+use ethereum_types::U64;
 use futures::TryFutureExt;
 use rand::Rng;
 use webb::evm::ethers::core::types::transaction::eip2718::TypedTransaction;
@@ -116,15 +116,13 @@ where
                 let maybe_item = store
                     .peek_item(SledQueueKey::from_evm_chain_id(chain_id))?;
                 let maybe_explorer = &chain_config.explorer;
-                let mut tx_hash: H256;
                 let Some(item) = maybe_item else {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                     continue;
                 };
                 let mut raw_tx = item.clone().inner();
                 raw_tx.set_chain_id(U64::from(chain_id));
-                let my_tx_hash = raw_tx.sighash();
-                tx_hash = my_tx_hash;
+                let tx_hash = raw_tx.sighash();
 
                 let tx_item_key = item.clone().inner().item_key();
 
@@ -236,7 +234,7 @@ where
                 let pending_tx = client.send_transaction(raw_tx.clone(), None);
                 let tx = match pending_tx.await {
                     Ok(pending) => {
-                        tx_hash = *pending;
+                        let signed_tx_hash = *pending;
                         tracing::event!(
                             target: webb_relayer_utils::probe::TARGET,
                             tracing::Level::DEBUG,
@@ -244,10 +242,11 @@ where
                             ty = "EVM",
                             chain_id = %chain_id,
                             pending = true,
-                            %tx_hash,
+                            raw_tx_hash = %tx_hash,
+                            %signed_tx_hash,
                         );
 
-                        let tx_hash_string = format!("0x{tx_hash:x}");
+                        let tx_hash_string = format!("0x{signed_tx_hash:x}");
                         if let Some(mut url) = maybe_explorer.clone() {
                             url.set_path(&format!("tx/{tx_hash_string}"));
                             let clickable_link = ClickableLink::new(
@@ -309,7 +308,7 @@ where
                             ty = "EVM",
                             chain_id = %chain_id,
                             errored = true,
-                            %tx_hash,
+                            raw_tx_hash = %tx_hash,
                             error = %e,
                         );
 
@@ -368,8 +367,8 @@ where
                             ty = "EVM",
                             chain_id = %chain_id,
                             finalized = true,
-                            %tx_hash,
-                        );
+                            raw_tx_hash = %tx_hash,
+                            signed_tx_hash = %receipt.transaction_hash,                        );
 
                         // update transaction progress as processed
                         store.shift_item_to_end(

--- a/crates/tx-queue/src/evm/evm_tx_queue.rs
+++ b/crates/tx-queue/src/evm/evm_tx_queue.rs
@@ -368,7 +368,8 @@ where
                             chain_id = %chain_id,
                             finalized = true,
                             raw_tx_hash = %tx_hash,
-                            signed_tx_hash = %receipt.transaction_hash,                        );
+                            signed_tx_hash = %receipt.transaction_hash,
+                        );
 
                         // update transaction progress as processed
                         store.shift_item_to_end(


### PR DESCRIPTION
## Summary of changes
-  We were using the `peak_item()` function to get the data which just fetched all the items with the given prefix and return first item from it
```rust
let prefix = tree.get("key_prefix")?.unwrap_or_else(|| b"item".into());
        let mut queue = tree.scan_prefix(prefix);
        let (_, value) = match queue.next() {
            Some(Ok(v)) => v,
            _ => return Ok(None),
        };
```
created a new function `get_item` which will return a specific item from the queue

- [x] Fixed bug
- [x] Added test
- [x] Added local dev config


### Reference issue to close (if applicable)
- Closes #572 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
