### PR TITLE
Update Orbit Network native token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8296,7 +8296,7 @@ dependencies = [
 
 [[package]]
 name = "webb-bridge-registry-backends"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "async-trait",
  "ethereum-types",
@@ -8315,7 +8315,7 @@ dependencies = [
 
 [[package]]
 name = "webb-chains-info"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -8354,7 +8354,7 @@ dependencies = [
 
 [[package]]
 name = "webb-event-watcher-traits"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "async-trait",
  "backoff",
@@ -8375,7 +8375,7 @@ dependencies = [
 
 [[package]]
 name = "webb-ew-dkg"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "async-trait",
  "ethereum-types",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "webb-ew-evm"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "webb-price-oracle-backends"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -8464,7 +8464,7 @@ dependencies = [
 
 [[package]]
 name = "webb-proposal-signing-backends"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "async-trait",
  "ethereum-types",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -8538,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-config"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "anyhow",
  "config",
@@ -8564,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-context"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "http",
  "native-tls",
@@ -8584,7 +8584,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-handler-utils"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "native-tls",
  "serde",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-handlers"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "axum",
  "axum-client-ip",
@@ -8622,7 +8622,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-store"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "hex",
  "native-tls",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-tx-queue"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "backoff",
  "ethereum-types",
@@ -8663,7 +8663,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-tx-relay"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "chrono",
  "ethereum-types",
@@ -8687,7 +8687,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-tx-relay-utils"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "native-tls",
  "serde",
@@ -8695,7 +8695,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-types"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "ethereum-types",
  "http",
@@ -8712,7 +8712,7 @@ dependencies = [
 
 [[package]]
 name = "webb-relayer-utils"
-version = "0.5.13-dev"
+version = "0.5.14-dev"
 dependencies = [
  "ark-std",
  "async-trait",

--- a/crates/chains-info/fixtures/chains.json
+++ b/crates/chains-info/fixtures/chains.json
@@ -14032,7 +14032,7 @@
     "chain": "athena",
     "rpc": ["https://athena-testnet.webb.tools"],
     "faucets": [],
-    "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
+    "nativeCurrency": { "name": "Webb Orbit Token", "symbol": "ORBt", "decimals": 18 },
     "infoURL": "https://webb.tools",
     "shortName": "athena",
     "chainId": 3884533461,
@@ -14040,7 +14040,7 @@
     "status": "testnet",
     "explorers": [
       {
-        "name": "athena explorer",
+        "name": "Athena Explorer",
         "url": "https://athena-explorer.webb.tools",
         "standard": "eip3091"
       }
@@ -14051,7 +14051,7 @@
     "chain": "hermes",
     "rpc": ["https://hermes-testnet.webb.tools"],
     "faucets": [],
-    "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
+    "nativeCurrency": { "name": "Webb Orbit Token", "symbol": "ORBt", "decimals": 18 },
     "infoURL": "https://webb.tools",
     "shortName": "hermes",
     "chainId": 3884533462,
@@ -14059,7 +14059,7 @@
     "status": "testnet",
     "explorers": [
       {
-        "name": "hermes explorer",
+        "name": "Hermes Explorer",
         "url": "https://hermes-explorer.webb.tools",
         "standard": "eip3091"
       }
@@ -14070,7 +14070,7 @@
     "chain": "demeter",
     "rpc": ["https://demeter-testnet.webb.tools"],
     "faucets": [],
-    "nativeCurrency": { "name": "Ether", "symbol": "ETH", "decimals": 18 },
+    "nativeCurrency": { "name": "Webb Orbit Token", "symbol": "ORBt", "decimals": 18 },
     "infoURL": "https://webb.tools",
     "shortName": "demeter",
     "chainId": 3884533463,
@@ -14078,7 +14078,7 @@
     "status": "testnet",
     "explorers": [
       {
-        "name": "demeter explorer",
+        "name": "Demeter Explorer",
         "url": "https://demeter-explorer.webb.tools",
         "standard": "eip3091"
       }
@@ -14127,7 +14127,7 @@
     "name": "Tangle testnet",
     "chain": "tangle",
     "rpc": [
-      "https://tangle-standalone-archive.webb.tools"
+      "https://rpc.tangle.tools"
     ],
     "faucets": [],
     "nativeCurrency": {
@@ -14135,15 +14135,15 @@
       "symbol": "tTNT",
       "decimals": 18
     },
-    "infoURL": "https://webb.tools",
+    "infoURL": "https://tangle.tools",
     "shortName": "tangle",
     "chainId": 4006,
     "networkId": 4006,
     "status": "testnet",
     "explorers": [
       {
-        "name": "tangle explorer",
-        "url": "https://tangle-testnet-explorer.webb.tools",
+        "name": "Tangle Explorer",
+        "url": "https://explorer.tangle.tools",
         "standard": "eip3091"
       }
     ]

--- a/crates/relayer-config/src/defaults.rs
+++ b/crates/relayer-config/src/defaults.rs
@@ -48,6 +48,6 @@ pub fn unlisted_assets() -> HashMap<String, crate::UnlistedAssetConfig> {
                 decimals: 18,
                 price: 0.10,
             },
-        )
+        ),
     ])
 }

--- a/crates/relayer-config/src/defaults.rs
+++ b/crates/relayer-config/src/defaults.rs
@@ -40,5 +40,14 @@ pub fn unlisted_assets() -> HashMap<String, crate::UnlistedAssetConfig> {
                 price: 0.10,
             },
         ),
+        // Orbit Network
+        (
+            String::from("ORBt"),
+            crate::UnlistedAssetConfig {
+                name: String::from("Webb Orbit Network Token"),
+                decimals: 18,
+                price: 0.10,
+            },
+        )
     ])
 }


### PR DESCRIPTION
## Summary of changes
- Updates Native Token from ETH to ORBt
- Adds a default price for the ORBt that is equal to tTNT


### Reference issue to close (if applicable)
- Closes #582 

-----
### Code Checklist 

- [ ] Tested
- [ ] Documented
